### PR TITLE
현장관리 리스트 조회 비즈니스 로직

### DIFF
--- a/csm-api/entity/project.go
+++ b/csm-api/entity/project.go
@@ -1,0 +1,142 @@
+package entity
+
+import (
+	"database/sql"
+	"time"
+)
+
+type ProjectInfo struct {
+	Sno              int64     `json:"sno"`
+	Jno              int64     `json:"jno"`
+	IsUse            string    `json:"is_use"`
+	IsDefault        string    `json:"is_default"`
+	RegDate          time.Time `json:"reg_date"`
+	RegUser          string    `json:"reg_user"`
+	RegUno           int64     `json:"reg_uno"`
+	ModDate          time.Time `json:"mod_date"`
+	ModUser          string    `json:"mod_user"`
+	ModUno           string    `json:"mod_uno"`
+	ProjectType      string    `json:"project_type"`
+	ProjectNo        string    `json:"project_no"`
+	ProjectNm        string    `json:"project_nm"`
+	ProjectYear      int64     `json:"project_year"`
+	ProjectLoc       string    `json:"project_loc"`
+	ProjectCode      string    `json:"project_code"`
+	ProjectCodeName  string    `json:"project_code_name"`
+	SiteNm           string    `json:"site_nm"`
+	CompCode         string    `json:"comp_code"`
+	CompNick         string    `json:"comp_nick"`
+	CompName         string    `json:"comp_name"`
+	CompEtc          string    `json:"comp_etc"`
+	OrderCompCode    string    `json:"order_comp_code"`
+	OrderCompNick    string    `json:"order_comp_nick"`
+	OrderCompName    string    `json:"order_comp_name"`
+	OrderCompJobName string    `json:"order_comp_job_name"`
+	ProjectLocName   string    `json:"project_loc_name"`
+	JobPm            string    `json:"job_pm"`
+	JobPe            string    `json:"job_pe"`
+	ProjectStdt      time.Time `json:"project_stdt"`
+	ProjectEddt      time.Time `json:"project_eddt"`
+	ProjectRegDate   time.Time `json:"project_reg_date"`
+	ProjectModDate   time.Time `json:"project_mod_date"`
+	ProjectState     string    `json:"project_state"`
+	MocNo            string    `json:"moc_no"`
+	WoNo             string    `json:"wo_no"`
+
+	ProjectPmList    *UserPmPeInfos `json:"project_pm_list"`
+	DailyContentList *ProjectDailys `json:"daily_content_list"`
+}
+
+type ProjectInfos []*ProjectInfo
+
+type ProjectInfoSql struct {
+	Sno              sql.NullInt64  `db:"SNO"`
+	Jno              sql.NullInt64  `db:"JNO"`
+	IsUse            sql.NullString `db:"IS_USE"`
+	IsDefault        sql.NullString `db:"IS_DEFAULT"`
+	RegDate          sql.NullTime   `db:"REG_DATE"`
+	RegUser          sql.NullString `db:"REG_USER"`
+	RegUno           sql.NullInt64  `db:"REG_UNO"`
+	ModDate          sql.NullTime   `db:"MOD_DATE"`
+	ModUser          sql.NullString `db:"MOD_USER"`
+	ModUno           sql.NullString `db:"MOD_UNO"`
+	ProjectType      sql.NullString `db:"PROJECT_TYPE"`
+	ProjectNo        sql.NullString `db:"PROJECT_NO"`
+	ProjectNm        sql.NullString `db:"PROJECT_NM"`
+	ProjectYear      sql.NullInt64  `db:"PROJECT_YEAR"`
+	ProjectLoc       sql.NullString `db:"PROJECT_LOC"`
+	ProjectCode      sql.NullString `db:"PROJECT_CODE"`
+	ProjectCodeName  sql.NullString `db:"PROJECT_CODE_NAME"`
+	SiteNm           sql.NullString `db:"SITE_NM"`
+	CompCode         sql.NullString `db:"COMP_CODE"`
+	CompNick         sql.NullString `db:"COMP_NICK"`
+	CompName         sql.NullString `db:"COMP_NAME"`
+	CompEtc          sql.NullString `db:"COMP_ETC"`
+	OrderCompCode    sql.NullString `db:"ORDER_COMP_CODE"`
+	OrderCompNick    sql.NullString `db:"ORDER_COMP_NICK"`
+	OrderCompName    sql.NullString `db:"ORDER_COMP_NAME"`
+	OrderCompJobName sql.NullString `db:"ORDER_COMP_JOB_NAME"`
+	ProjectLocName   sql.NullString `db:"PROJECT_LOC_NAME"`
+	JobPm            sql.NullString `db:"JOB_PM"`
+	JobPe            sql.NullString `db:"JOB_PE"`
+	ProjectStdt      sql.NullTime   `db:"PROJECT_STDT"`
+	ProjectEddt      sql.NullTime   `db:"PROJECT_EDDT"`
+	ProjectRegDate   sql.NullTime   `db:"PROJECT_REG_DATE"`
+	ProjectModDate   sql.NullTime   `db:"PROJECT_MOD_DATE"`
+	ProjectState     sql.NullString `db:"PROJECT_STATE"`
+	MocNo            sql.NullString `db:"MOC_NO"`
+	WoNo             sql.NullString `db:"WO_NO"`
+}
+
+type ProjectInfoSqls []*ProjectInfoSql
+
+func (p *ProjectInfo) ToProjectInfo(projectInfoSql *ProjectInfoSql) *ProjectInfo {
+	p.Sno = projectInfoSql.Sno.Int64
+	p.Jno = projectInfoSql.Jno.Int64
+	p.IsUse = projectInfoSql.IsUse.String
+	p.IsDefault = projectInfoSql.IsDefault.String
+	p.RegDate = projectInfoSql.RegDate.Time
+	p.RegUser = projectInfoSql.RegUser.String
+	p.RegUno = projectInfoSql.RegUno.Int64
+	p.ModDate = projectInfoSql.ModDate.Time
+	p.ModUser = projectInfoSql.ModUser.String
+	p.ModUno = projectInfoSql.ModUno.String
+	p.ProjectType = projectInfoSql.ProjectType.String
+	p.ProjectNo = projectInfoSql.ProjectNo.String
+	p.ProjectNm = projectInfoSql.ProjectNm.String
+	p.ProjectYear = projectInfoSql.ProjectYear.Int64
+	p.ProjectLoc = projectInfoSql.ProjectLoc.String
+	p.ProjectCode = projectInfoSql.ProjectCode.String
+	p.ProjectCodeName = projectInfoSql.ProjectCodeName.String
+	p.SiteNm = projectInfoSql.SiteNm.String
+	p.CompCode = projectInfoSql.CompCode.String
+	p.CompNick = projectInfoSql.CompNick.String
+	p.CompName = projectInfoSql.CompName.String
+	p.CompEtc = projectInfoSql.CompEtc.String
+	p.OrderCompCode = projectInfoSql.OrderCompCode.String
+	p.OrderCompNick = projectInfoSql.OrderCompNick.String
+	p.OrderCompName = projectInfoSql.OrderCompName.String
+	p.OrderCompJobName = projectInfoSql.OrderCompJobName.String
+	p.ProjectLocName = projectInfoSql.ProjectLoc.String
+	p.JobPe = projectInfoSql.JobPe.String
+	p.JobPe = projectInfoSql.JobPe.String
+	p.ProjectStdt = projectInfoSql.ProjectStdt.Time
+	p.ProjectEddt = projectInfoSql.ProjectEddt.Time
+	p.ProjectRegDate = projectInfoSql.ProjectRegDate.Time
+	p.ProjectModDate = projectInfoSql.ProjectModDate.Time
+	p.ProjectState = projectInfoSql.ProjectState.String
+	p.MocNo = projectInfoSql.MocNo.String
+	p.WoNo = projectInfoSql.WoNo.String
+
+	return p
+}
+
+func (p *ProjectInfos) ToProjectInfos(projectInfoSqls *ProjectInfoSqls) *ProjectInfos {
+	for _, projectInfoSql := range *projectInfoSqls {
+		projectInfo := ProjectInfo{}
+		projectInfo.ToProjectInfo(projectInfoSql)
+		*p = append(*p, &projectInfo)
+	}
+
+	return p
+}

--- a/csm-api/entity/project_daily.go
+++ b/csm-api/entity/project_daily.go
@@ -1,0 +1,17 @@
+package entity
+
+import "time"
+
+type ProjectDaily struct {
+	Jno     int64     `json:"jno" db:"JNO"`
+	Content string    `json:"content" db:"CONTENT"`
+	IsUse   string    `json:"isUse" db:"IS_USE"`
+	RegDate time.Time `json:"regDate" db:"REG_DATE"`
+	RegUno  int64     `json:"regUno" db:"REG_UNO"`
+	RegUser string    `json:"regUser" db:"REG_USER"`
+	ModDate time.Time `json:"modDate" db:"MOD_DATE"`
+	ModUno  int64     `json:"modUno" db:"MOD_UNO"`
+	ModUser string    `json:"modUser" db:"MOD_USER"`
+}
+
+type ProjectDailys []*ProjectDaily

--- a/csm-api/entity/site.go
+++ b/csm-api/entity/site.go
@@ -1,0 +1,81 @@
+package entity
+
+import (
+	"database/sql"
+	"time"
+)
+
+type Site struct {
+	Sno                int64     `json:"sno"`
+	SiteNm             string    `json:"site_nm"`
+	Etc                string    `json:"etc"`
+	LocCode            string    `json:"loc_code"`
+	LocName            string    `json:"loc_name"`
+	IsUse              string    `json:"is_use"`
+	RegDate            time.Time `json:"reg_date"`
+	RegUser            string    `json:"reg_user"`
+	RegUno             int64     `json:"reg_uno"`
+	ModDate            time.Time `json:"mod_date"`
+	ModUser            string    `json:"mod_user"`
+	ModUno             int64     `json:"mod_uno"`
+	DefaultJno         int64     `json:"default_jno"`
+	DefaultProjectName string    `json:"default_project_name"`
+	DefaultProjectNo   string    `json:"default_project_no"`
+
+	ProjectList *ProjectInfos `json:"project_list"`
+	SitePos     *SitePos      `json:"site_pos"`
+	SiteDate    *SiteDate     `json:"site_date"`
+}
+
+type Sites []*Site
+
+type SiteSql struct {
+	Sno                sql.NullInt64  `db:"SNO"`
+	SiteNm             sql.NullString `db:"SITE_NM"`
+	Etc                sql.NullString `db:"ETC"`
+	LocCode            sql.NullString `db:"LOC_CODE"`
+	LocName            sql.NullString `db:"LOC_NAME"`
+	IsUse              sql.NullString `db:"IS_USE"`
+	RegDate            sql.NullTime   `db:"REG_DATE"`
+	RegUser            sql.NullString `db:"REG_USER"`
+	RegUno             sql.NullInt64  `db:"REG_UNO"`
+	ModDate            sql.NullTime   `db:"MOD_DATE"`
+	ModUser            sql.NullString `db:"MOD_USER"`
+	ModUno             sql.NullInt64  `db:"MOD_UNO"`
+	DefaultJno         sql.NullInt64  `db:"DEFAULT_JNO"`
+	DefaultProjectName sql.NullString `db:"DEFAULT_PROJECT_NAME"`
+	DefaultProjectNo   sql.NullString `db:"DEFAULT_PROJECT_NO"`
+	CurrentSiteStats   sql.NullString `db:"CURRENT_SITE_STATS"`
+}
+
+type SiteSqls []*SiteSql
+
+func (s *Site) ToSite(siteSql *SiteSql) *Site {
+	s.Sno = siteSql.Sno.Int64
+	s.SiteNm = siteSql.SiteNm.String
+	s.Etc = siteSql.Etc.String
+	s.LocCode = siteSql.LocCode.String
+	s.LocName = siteSql.LocName.String
+	s.IsUse = siteSql.IsUse.String
+	s.RegDate = siteSql.RegDate.Time
+	s.RegUser = siteSql.RegUser.String
+	s.RegUno = siteSql.RegUno.Int64
+	s.ModDate = siteSql.ModDate.Time
+	s.ModUser = siteSql.ModUser.String
+	s.ModUno = siteSql.ModUno.Int64
+	s.DefaultJno = siteSql.DefaultJno.Int64
+	s.DefaultProjectName = siteSql.DefaultProjectName.String
+	s.DefaultProjectNo = siteSql.DefaultProjectNo.String
+
+	return s
+}
+
+func (s *Sites) ToSites(siteSqls *SiteSqls) *Sites {
+	for _, siteSql := range *siteSqls {
+		site := Site{}
+		site.ToSite(siteSql)
+		*s = append(*s, &site)
+	}
+
+	return s
+}

--- a/csm-api/entity/site_date.go
+++ b/csm-api/entity/site_date.go
@@ -1,0 +1,38 @@
+package entity
+
+import (
+	"database/sql"
+	"time"
+)
+
+type SiteDate struct {
+	OpeningDate         time.Time `json:"opening_date"`
+	ClosingPlanDate     time.Time `json:"closing_plan_date"`
+	ClosingForecastDate time.Time `json:"closing_forecast_date"`
+	ClosingActualDate   time.Time `json:"closing_actual_date"`
+	RegUno              int64     `json:"reg_uno"`
+	RegUser             string    `json:"reg_user"`
+	RegDate             time.Time `json:"reg_date"`
+}
+
+type SiteDateSql struct {
+	OpeningDate         sql.NullTime   `db:"OPENING_DATE"`
+	ClosingPlanDate     sql.NullTime   `db:"CLOSING_PLAN_DATE"`
+	ClosingForecastDate sql.NullTime   `db:"CLOSING_FORECAST_DATE"`
+	ClosingActualDate   sql.NullTime   `db:"CLOSING_ACTUAL_DATE"`
+	RegUno              sql.NullInt64  `db:"REG_UNO"`
+	RegUser             sql.NullString `db:"REG_USER"`
+	RegDate             sql.NullTime   `db:"REG_DATE"`
+}
+
+func (s *SiteDate) ToSiteDate(sql *SiteDateSql) *SiteDate {
+	s.OpeningDate = sql.OpeningDate.Time
+	s.ClosingPlanDate = sql.ClosingPlanDate.Time
+	s.ClosingForecastDate = sql.ClosingForecastDate.Time
+	s.ClosingActualDate = sql.ClosingActualDate.Time
+	s.RegUno = sql.RegUno.Int64
+	s.RegUser = sql.RegUser.String
+	s.RegDate = sql.RegDate.Time
+
+	return s
+}

--- a/csm-api/entity/site_pos.go
+++ b/csm-api/entity/site_pos.go
@@ -1,0 +1,56 @@
+package entity
+
+import (
+	"database/sql"
+	"time"
+)
+
+type SitePos struct {
+	AddressNameDepth1     string    `json:"address_name_depth1"`
+	AddressNameDepth2     string    `json:"address_name_depth2"`
+	AddressNameDepth3     string    `json:"address_name_depth3"`
+	AddressNameDepth4     string    `json:"address_name_depth4"`
+	AddressNameDepth5     string    `json:"address_name_depth5"`
+	RoadAddressNameDepth1 string    `json:"road_address_name_depth1"`
+	RoadAddressNameDepth2 string    `json:"road_address_name_depth2"`
+	RoadAddressNameDepth3 string    `json:"road_address_name_depth3"`
+	RoadAddressNameDepth4 string    `json:"road_address_name_depth4"`
+	RoadAddressNameDepth5 string    `json:"road_address_name_depth5"`
+	Latitude              float64   `json:"latitude"`
+	Longitude             float64   `json:"longitude"`
+	RegDate               time.Time `json:"reg_date"`
+}
+
+type SitePosSql struct {
+	AddressNameDepth1     sql.NullString  `db:"ADDRESS_NAME_DEPTH1"`
+	AddressNameDepth2     sql.NullString  `db:"ADDRESS_NAME_DEPTH2"`
+	AddressNameDepth3     sql.NullString  `db:"ADDRESS_NAME_DEPTH3"`
+	AddressNameDepth4     sql.NullString  `db:"ADDRESS_NAME_DEPTH4"`
+	AddressNameDepth5     sql.NullString  `db:"ADDRESS_NAME_DEPTH5"`
+	RoadAddressNameDepth1 sql.NullString  `db:"ROAD_ADDRESS_NAME_DEPTH1"`
+	RoadAddressNameDepth2 sql.NullString  `db:"ROAD_ADDRESS_NAME_DEPTH2"`
+	RoadAddressNameDepth3 sql.NullString  `db:"ROAD_ADDRESS_NAME_DEPTH3"`
+	RoadAddressNameDepth4 sql.NullString  `db:"ROAD_ADDRESS_NAME_DEPTH4"`
+	RoadAddressNameDepth5 sql.NullString  `db:"ROAD_ADDRESS_NAME_DEPTH5"`
+	Latitude              sql.NullFloat64 `db:"LATITUDE"`
+	Longitude             sql.NullFloat64 `db:"LONGITUDE"`
+	RegDate               sql.NullTime    `db:"REG_DATE"`
+}
+
+func (s *SitePos) ToSitePos(sql *SitePosSql) *SitePos {
+	s.AddressNameDepth1 = sql.AddressNameDepth1.String
+	s.AddressNameDepth2 = sql.AddressNameDepth2.String
+	s.AddressNameDepth3 = sql.AddressNameDepth3.String
+	s.AddressNameDepth4 = sql.AddressNameDepth4.String
+	s.AddressNameDepth5 = sql.AddressNameDepth5.String
+	s.RoadAddressNameDepth1 = sql.RoadAddressNameDepth1.String
+	s.RoadAddressNameDepth2 = sql.RoadAddressNameDepth2.String
+	s.RoadAddressNameDepth3 = sql.RoadAddressNameDepth3.String
+	s.RoadAddressNameDepth4 = sql.RoadAddressNameDepth4.String
+	s.RoadAddressNameDepth5 = sql.RoadAddressNameDepth5.String
+	s.Latitude = sql.Latitude.Float64
+	s.Longitude = sql.Longitude.Float64
+	s.RegDate = sql.RegDate.Time
+
+	return s
+}

--- a/csm-api/entity/user.go
+++ b/csm-api/entity/user.go
@@ -1,7 +1,43 @@
 package entity
 
+import "database/sql"
+
 type User struct {
 	UserId   string `json:"user_id" db:"USER_ID"`
 	UserName string `json:"user_name" db:"USER_NAME"`
 	UserPwd  string `json:"user_pwd" db:"USER_PWD"`
+}
+
+type UserPmPeInfo struct {
+	Uno    int64  `json:"uno"`
+	UserId string `json:"user_id"`
+	Name   string `json:"name"`
+}
+
+type UserPmPeInfos []*UserPmPeInfo
+
+type UserPmPeInfoSql struct {
+	Uno    sql.NullInt64  `db:"UNO"`
+	UserId sql.NullString `db:"USER_ID"`
+	Name   sql.NullString `db:"USER_NAME"`
+}
+
+type UserPmPeInfoSqls []*UserPmPeInfoSql
+
+func (u *UserPmPeInfo) ToUserPmPeInfo(sql *UserPmPeInfoSql) *UserPmPeInfo {
+	u.Uno = sql.Uno.Int64
+	u.UserId = sql.UserId.String
+	u.Name = sql.Name.String
+
+	return u
+}
+
+func (u *UserPmPeInfos) ToUserPmPeInfos(sqls *UserPmPeInfoSqls) *UserPmPeInfos {
+	for _, sql := range *sqls {
+		info := UserPmPeInfo{}
+		info.ToUserPmPeInfo(sql)
+		*u = append(*u, &info)
+	}
+
+	return u
 }

--- a/csm-api/handler/login_handler.go
+++ b/csm-api/handler/login_handler.go
@@ -41,7 +41,7 @@ func (l *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ctx,
 			w,
 			&ErrResponse{
-				Result:         "failed",
+				Result:         Failure,
 				Message:        err.Error(),
 				Details:        InvalidUser,
 				HttpStatusCode: http.StatusInternalServerError,
@@ -57,7 +57,7 @@ func (l *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			ctx,
 			w,
 			&ErrResponse{
-				Result:         "jwt created failed",
+				Result:         Failure,
 				Message:        err.Error(),
 				Details:        TokenCreatedFail,
 				HttpStatusCode: http.StatusInternalServerError,

--- a/csm-api/handler/response.go
+++ b/csm-api/handler/response.go
@@ -22,6 +22,8 @@ const (
 	BodyDataParseError  ErrDetailsRole = "Body Data Parse Error"
 	InvalidUser         ErrDetailsRole = "Invalid User"
 	TokenCreatedFail    ErrDetailsRole = "Token Created Fail"
+	NotFoundParam       ErrDetailsRole = "Not Found Parameter"
+	ParsingError        ErrDetailsRole = "Parsing Error"
 )
 
 type ErrResponse struct {

--- a/csm-api/handler/site_list_handler.go
+++ b/csm-api/handler/site_list_handler.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"csm-api/auth"
+	"csm-api/service"
+	"net/http"
+	"time"
+)
+
+type SiteListHandler struct {
+	Service service.SiteService
+	Jwt     *auth.JWTUtils
+}
+
+func (s *SiteListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// GET 요청에서 파라미터 값 읽기
+	targetDateString := r.URL.Query().Get("targetDate")
+	if targetDateString == "" {
+		RespondJSON(
+			ctx,
+			w,
+			&ErrResponse{
+				Result:         Failure,
+				Message:        "targetDate parameter is missing",
+				Details:        NotFoundParam,
+				HttpStatusCode: http.StatusBadRequest,
+			},
+			http.StatusOK)
+		return
+	}
+	targetDate, err := time.Parse("2006-01-02", targetDateString)
+	if err != nil {
+		RespondJSON(
+			ctx,
+			w,
+			&ErrResponse{
+				Result:         Failure,
+				Message:        "Error parsing targetDate",
+				Details:        ParsingError,
+				HttpStatusCode: http.StatusInternalServerError,
+			},
+			http.StatusOK)
+		return
+	}
+
+	// 현장 관리 리스트 조회
+	sites, err := s.Service.GetSiteList(ctx, targetDate)
+	if err != nil {
+		RespondJSON(
+			ctx,
+			w,
+			&ErrResponse{
+				Result:         Failure,
+				Message:        err.Error(),
+				Details:        InvalidUser,
+				HttpStatusCode: http.StatusInternalServerError,
+			},
+			http.StatusOK)
+		return
+	}
+
+	rsp := Response{
+		Result: Success,
+		Values: sites,
+	}
+
+	RespondJSON(ctx, w, &rsp, http.StatusOK)
+
+}

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -58,6 +58,36 @@ func newMux(ctx context.Context, cfg *config.DBConfigs) (http.Handler, []func(),
 	}
 	mux.Get("/jwt-validation", jwtVaildHandler.ServeHTTP)
 
+	// 현장관리 리스트 조회
+	siteListHandler := &handler.SiteListHandler{
+		Service: &service.ServiceSite{
+			DB:    safeDb,
+			Store: &r,
+			ProjectService: &service.ServiceProject{
+				DB:    safeDb,
+				Store: &r,
+				UserService: &service.ServiceUser{
+					DB:    safeDb,
+					Store: &r,
+				},
+			},
+			ProjectDailyService: &service.ServiceProjectDaily{
+				DB:    safeDb,
+				Store: &r,
+			},
+			SitePosService: &service.ServiceSitePos{
+				DB:    safeDb,
+				Store: &r,
+			},
+			SiteDateService: &service.ServiceSiteDate{
+				DB:    safeDb,
+				Store: &r,
+			},
+		},
+		Jwt: jwt,
+	}
+	mux.Get("/site-list", siteListHandler.ServeHTTP)
+
 	// 미들웨어를 사용하여 토큰 검사 후 ServeHTTP 실행
 	mux.Route("/test", func(r chi.Router) {
 		r.Use(handler.AuthMiddleware(jwt))

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -3,8 +3,33 @@ package service
 import (
 	"context"
 	"csm-api/entity"
+	"time"
 )
 
 type GetUserValidService interface {
 	GetUserValid(ctx context.Context, userId string, userPwd string) (entity.User, error)
+}
+
+type SiteService interface {
+	GetSiteList(ctx context.Context, targetDate time.Time) (*entity.Sites, error)
+}
+
+type SitePosService interface {
+	GetSitePosData(ctx context.Context, sno int64) (*entity.SitePos, error)
+}
+
+type SiteDateService interface {
+	GetSiteDateData(ctx context.Context, sno int64) (*entity.SiteDate, error)
+}
+
+type ProjectService interface {
+	GetProjectList(ctx context.Context, sno int64) (*entity.ProjectInfos, error)
+}
+
+type ProjectDailyService interface {
+	GetProjectDailyContentList(ctx context.Context, jno int64, targetDate time.Time) (*entity.ProjectDailys, error)
+}
+
+type UserService interface {
+	GetUserInfoPmPeList(ctx context.Context, unoList []int) (*entity.UserPmPeInfos, error)
 }

--- a/csm-api/service/service_project.go
+++ b/csm-api/service/service_project.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ServiceProject struct {
+	DB          store.Queryer
+	Store       store.ProjectStore
+	UserService UserService
+}
+
+// 현장 고유번호로 현장에 해당하는 프로젝트 리스트 조회 비즈니스
+//
+// @param sno: 현장 고유번호
+func (p *ServiceProject) GetProjectList(ctx context.Context, sno int64) (*entity.ProjectInfos, error) {
+	projectInfoSqls, err := p.Store.GetProjectList(ctx, p.DB, sno)
+	if err != nil {
+		return &entity.ProjectInfos{}, fmt.Errorf("service_project/getProjectList error: %w", err)
+	}
+	projectInfos := &entity.ProjectInfos{}
+	projectInfos.ToProjectInfos(projectInfoSqls)
+
+	// 프로젝트 정보 객체에 pm, pe 정보 삽입
+	for _, projectInfo := range *projectInfos {
+		var unoList []int
+		// pm uno 조회
+		if &projectInfo.JobPm != nil && projectInfo.JobPm != "" {
+			uno, err := strconv.Atoi(projectInfo.JobPm)
+			if err != nil {
+				return &entity.ProjectInfos{}, fmt.Errorf("service_project/strconv.Atoi(projectInfo.JobPm) parse err")
+			}
+			unoList = append(unoList, uno)
+		}
+
+		// pe uno 조회
+		if &projectInfo.JobPe != nil && projectInfo.JobPe != "" {
+			jobPeList := strings.Split(projectInfo.JobPe, ",")
+			for _, jonPe := range jobPeList {
+				uno, err := strconv.Atoi(jonPe)
+				if err != nil {
+					return &entity.ProjectInfos{}, fmt.Errorf("service_project/strconv.Atoi(jonPe) parse err")
+				}
+				unoList = append(unoList, uno)
+			}
+		}
+
+		// pm, pe 정보 일괄 조회
+		userPmPeList, err := p.UserService.GetUserInfoPmPeList(ctx, unoList)
+		if err != nil {
+			return &entity.ProjectInfos{}, fmt.Errorf("service_project/GetUserInfoPmPeList error: %w", err)
+		}
+		projectInfo.ProjectPmList = userPmPeList
+	}
+
+	return projectInfos, nil
+}

--- a/csm-api/service/service_project_daily.go
+++ b/csm-api/service/service_project_daily.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+	"time"
+)
+
+type ServiceProjectDaily struct {
+	DB    store.Queryer
+	Store store.ProjectDailyStore
+}
+
+// 현장 고유번호로 현장에 해당하는 프로젝트 리스트 조회 비즈니스
+//
+// @param jno: 프로젝트 관리번호
+// @param targetDate: 현재 시간
+func (s *ServiceProjectDaily) GetProjectDailyContentList(ctx context.Context, jno int64, targetDate time.Time) (*entity.ProjectDailys, error) {
+	projectDailys, err := s.Store.GetProjectDailyContentList(ctx, s.DB, jno, targetDate)
+	if err != nil {
+		return nil, fmt.Errorf("service_project_daily/GetProjectDailyContentList err: %w", err)
+	}
+	return projectDailys, nil
+}

--- a/csm-api/service/service_site.go
+++ b/csm-api/service/service_site.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+	"time"
+)
+
+type ServiceSite struct {
+	DB                  store.Queryer
+	Store               store.SiteStore
+	ProjectService      ProjectService
+	ProjectDailyService ProjectDailyService
+	SitePosService      SitePosService
+	SiteDateService     SiteDateService
+}
+
+// 현장 관리 리스트 조회
+//
+// @param targetDate: ???
+func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*entity.Sites, error) {
+
+	//현장관리 테이블 조회
+	siteSqls, err := s.Store.GetSiteList(ctx, s.DB, targetDate)
+	if err != nil {
+		return &entity.Sites{}, fmt.Errorf("service_site/GetSiteList err: %w", err)
+	}
+	sites := &entity.Sites{}
+	sites.ToSites(siteSqls)
+
+	for _, site := range *sites {
+		sno := site.Sno
+
+		// 프로젝트 리스트 조회
+		projectInfos, err := s.ProjectService.GetProjectList(ctx, sno)
+		if err != nil {
+			return &entity.Sites{}, fmt.Errorf("service_site/GetProjectList err: %w", err)
+		}
+		site.ProjectList = projectInfos
+
+		for _, projectInfo := range *site.ProjectList {
+			if &projectInfo.Jno != nil {
+				projectDailyList, err := s.ProjectDailyService.GetProjectDailyContentList(ctx, projectInfo.Jno, targetDate)
+				if err != nil {
+					return &entity.Sites{}, fmt.Errorf("service_site/GetProjectDailyContentList err: %w", err)
+				}
+				projectInfo.DailyContentList = projectDailyList
+			}
+		}
+
+		// 현장 위치 조회
+		sitePosData, err := s.SitePosService.GetSitePosData(ctx, sno)
+		if err != nil {
+			return &entity.Sites{}, fmt.Errorf("service_site/GetSitePosData err: %w", err)
+		}
+		site.SitePos = sitePosData
+
+		// 현장 날씨 조회
+		siteDateData, err := s.SiteDateService.GetSiteDateData(ctx, sno)
+		if err != nil {
+			return &entity.Sites{}, fmt.Errorf("service_site/GetSiteDateData err: %w", err)
+		}
+		site.SiteDate = siteDateData
+	}
+
+	return sites, nil
+}

--- a/csm-api/service/service_site_date.go
+++ b/csm-api/service/service_site_date.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+)
+
+type ServiceSiteDate struct {
+	DB    store.Queryer
+	Store store.SiteDateStore
+}
+
+// 현장 날씨 테이블 조회
+//
+// @param sno: 현장 고유번호
+func (s *ServiceSiteDate) GetSiteDateData(ctx context.Context, sno int64) (*entity.SiteDate, error) {
+	siteDateSql, err := s.Store.GetSiteDateData(ctx, s.DB, sno)
+	if err != nil {
+		return nil, fmt.Errorf("service_site_date/GetSiteDateData err: %w", err)
+	}
+	siteDate := &entity.SiteDate{}
+	siteDate.ToSiteDate(siteDateSql)
+
+	return siteDate, nil
+}

--- a/csm-api/service/service_site_pos.go
+++ b/csm-api/service/service_site_pos.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+)
+
+type ServiceSitePos struct {
+	DB    store.Queryer
+	Store store.SitePosStore
+}
+
+// 현장 위치 테이블 조회
+//
+// @param sno: 현장 고유번호
+func (s *ServiceSitePos) GetSitePosData(ctx context.Context, sno int64) (*entity.SitePos, error) {
+	sitePosSql, err := s.Store.GetSitePosData(ctx, s.DB, sno)
+	if err != nil {
+		return nil, fmt.Errorf("service_site_pos/GetSitePosData err: %w", err)
+	}
+	sitePos := &entity.SitePos{}
+	sitePos.ToSitePos(sitePosSql)
+
+	return sitePos, nil
+}

--- a/csm-api/service/service_user.go
+++ b/csm-api/service/service_user.go
@@ -1,0 +1,27 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+)
+
+type ServiceUser struct {
+	DB    store.Queryer
+	Store store.UserStore
+}
+
+// 프로젝트 pm, pe 정보 조회
+//
+// @param unoList: ?? 고유번호 리스트
+func (u *ServiceUser) GetUserInfoPmPeList(ctx context.Context, unoList []int) (*entity.UserPmPeInfos, error) {
+	userPmPeInfoSqls, err := u.Store.GetUserInfoPmPeList(ctx, u.DB, unoList)
+	if err != nil {
+		return nil, fmt.Errorf("service_user/GetUserInfoPmPeList err: %w", err)
+	}
+	userPmPeInfos := &entity.UserPmPeInfos{}
+	userPmPeInfos.ToUserPmPeInfos(userPmPeInfoSqls)
+
+	return userPmPeInfos, nil
+}

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -3,8 +3,33 @@ package store
 import (
 	"context"
 	"csm-api/entity"
+	"time"
 )
 
 type GetUserValidStore interface {
 	GetUserValid(ctx context.Context, db Queryer, userId string, userPwd string) (entity.User, error)
+}
+
+type SiteStore interface {
+	GetSiteList(ctx context.Context, db Queryer, targetDate time.Time) (*entity.SiteSqls, error)
+}
+
+type SitePosStore interface {
+	GetSitePosData(ctx context.Context, db Queryer, sno int64) (*entity.SitePosSql, error)
+}
+
+type SiteDateStore interface {
+	GetSiteDateData(ctx context.Context, db Queryer, sno int64) (*entity.SiteDateSql, error)
+}
+
+type ProjectStore interface {
+	GetProjectList(ctx context.Context, db Queryer, sno int64) (*entity.ProjectInfoSqls, error)
+}
+
+type ProjectDailyStore interface {
+	GetProjectDailyContentList(ctx context.Context, db Queryer, jno int64, targetDate time.Time) (*entity.ProjectDailys, error)
+}
+
+type UserStore interface {
+	GetUserInfoPmPeList(ctx context.Context, db Queryer, unoList []int) (*entity.UserPmPeInfoSqls, error)
 }

--- a/csm-api/store/store_project.go
+++ b/csm-api/store/store_project.go
@@ -1,0 +1,73 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"database/sql"
+	"fmt"
+)
+
+func (r *Repository) GetProjectList(ctx context.Context, db Queryer, sno int64) (*entity.ProjectInfoSqls, error) {
+	projectInfoSqls := entity.ProjectInfoSqls{}
+
+	// sno 변환: 0이면 NULL 처리, 아니면 Valid 값으로 설정
+	var snoParam sql.NullInt64
+	if sno != 0 {
+		snoParam = sql.NullInt64{Valid: true, Int64: sno}
+	} else {
+		snoParam = sql.NullInt64{Valid: false}
+	}
+
+	sql := `SELECT
+				t1.SNO,
+				t1.JNO,
+				t1.IS_USE,
+				t1.IS_DEFAULT,
+				t1.REG_DATE,
+				t1.REG_USER,
+				t1.REG_UNO,
+				t1.MOD_DATE,
+				t1.MOD_USER,
+				t1.MOD_UNO,
+				t2.JOB_TYPE as PROJECT_TYPE,
+				t2.JOB_NO as PROJECT_NO,
+				t2.JOB_NAME as PROJECT_NM,
+				t2.JOB_YEAR as PROJECT_YEAR,
+				t2.JOB_LOC as PROJECT_LOC,
+				t2.JOB_CODE as PROJECT_CODE,
+				t4.KIND_NAME as PROJECT_CODE_NAME,
+				t3.SITE_NM,
+				t2.COMP_CODE,
+				t2.COMP_NICK,
+				t2.COMP_NAME,
+				t2.COMP_ETC,
+				t2.ORDER_COMP_CODE,
+				t2.ORDER_COMP_NICK,
+				t2.ORDER_COMP_NAME,
+				t2.ORDER_COMP_JOB_NAME,
+				t2.JOB_LOC_NAME as PROJECT_LOC_NAME,
+				t2.JOB_PM,
+				t2.JOB_PE,
+				TO_DATE(t2.JOB_SD, 'YYYY-MM-DD') as PROJECT_STDT,
+				TO_DATE(t2.JOB_ED, 'YYYY-MM-DD') as PROJECT_EDDT,
+				TO_DATE(t2.REG_DATE, 'YYYY-MM-DD HH24:MI:SS') as PROJECT_REG_DATE,
+				TO_DATE(t2.MOD_DATE, 'YYYY-MM-DD HH24:MI:SS') as PROJECT_MOD_DATE,
+				t2.JOB_STATE as PROJECT_STATE,
+				t2.MOC_NO,
+				t2.WO_NO
+			FROM
+				IRIS_SITE_JOB t1
+				INNER JOIN S_JOB_INFO t2 ON t1.JNO = t2.JNO
+				INNER JOIN IRIS_SITE_SET t3 ON t1.SNO = t3.SNO
+				INNER JOIN TIMESHEET.JOB_KIND_CODE t4 ON t2.JOB_CODE = t4.KIND_CODE
+			WHERE
+				t1.SNO > 100
+				AND (:1 IS NULL OR t1.SNO = :2)
+			ORDER BY
+				t1.IS_DEFAULT DESC`
+	if err := db.SelectContext(ctx, &projectInfoSqls, sql, snoParam, snoParam); err != nil {
+		return &projectInfoSqls, fmt.Errorf("getProjectList fail: %v", err)
+	}
+
+	return &projectInfoSqls, nil
+}

--- a/csm-api/store/store_project_daily.go
+++ b/csm-api/store/store_project_daily.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+func (r *Repository) GetProjectDailyContentList(ctx context.Context, db Queryer, jno int64, targetDate time.Time) (*entity.ProjectDailys, error) {
+	projectDailys := entity.ProjectDailys{}
+
+	// jno 변환: 0이면 NULL 처리, 아니면 Valid 값으로 설정
+	var jnoParam sql.NullInt64
+	if jno != 0 {
+		jnoParam = sql.NullInt64{Valid: true, Int64: jno}
+	} else {
+		jnoParam = sql.NullInt64{Valid: false}
+	}
+
+	// targetDate 변환: zero 값이면 NULL 처리, 아니면 Valid 값으로 설정
+	var targetDateParam sql.NullTime
+	if !targetDate.IsZero() {
+		targetDateParam = sql.NullTime{Valid: true, Time: targetDate}
+	} else {
+		targetDateParam = sql.NullTime{Valid: false}
+	}
+
+	sql := `SELECT 
+				t1.JNO,
+				t1.CONTENT,
+				t1.IS_USE,
+				t1.REG_DATE,
+				t1.MOD_DATE,
+				t1.REG_UNO,
+				t1.REG_USER,
+				t1.MOD_UNO,
+				t1.MOD_USER
+			FROM
+				IRIS_DAILY_JOB t1
+			WHERE
+				t1.IS_USE = 'Y'
+				AND (:1 IS NULL OR t1.JNO = :2)
+				AND (:3 IS NULL OR t1.TARGET_DATE = :4)
+			ORDER BY
+				NVL(t1.REG_DATE, t1.MOD_DATE) DESC`
+
+	if err := db.SelectContext(ctx, &projectDailys, sql, jnoParam, jnoParam, targetDateParam, targetDateParam); err != nil {
+		return nil, fmt.Errorf("GetProjectDailyContentList fail: %w", err)
+	}
+	return &projectDailys, nil
+}

--- a/csm-api/store/store_site.go
+++ b/csm-api/store/store_site.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"fmt"
+	"time"
+)
+
+func (r *Repository) GetSiteList(ctx context.Context, db Queryer, targetDate time.Time) (*entity.SiteSqls, error) {
+	siteSqls := entity.SiteSqls{}
+
+	sql := `SELECT
+				*
+			FROM (
+				WITH sour AS (
+					SELECT
+						t1.SNO
+						,t1.SITE_NM
+						,t1.ETC
+						,t1.LOC_CODE
+						,t1.LOC_NAME
+						,t1.IS_USE
+						,t1.REG_DATE
+						,t1.REG_USER
+						,t1.REG_UNO
+						,t1.MOD_DATE
+						,t1.MOD_USER
+						,t1.MOD_UNO
+						,t2.JNO AS DEFAULT_JNO
+						,t3.JOB_NAME AS DEFAULT_PROJECT_NAME
+						,t3.JOB_NO AS DEFAULT_PROJECT_NO
+					FROM
+						IRIS_SITE_SET t1
+						INNER JOIN IRIS_SITE_JOB t2 ON t1.SNO = t2.SNO AND t2.IS_DEFAULT = 'Y'
+						INNER JOIN S_JOB_INFO t3 ON t2.JNO = t3.JNO
+					WHERE
+						t1.sno > 100
+					ORDER BY
+						t1.SNO DESC
+				)
+				SELECT
+					sour.*,
+					NVL(iss.STATS, 'Y') AS CURRENT_SITE_STATS
+				FROM
+					sour
+				LEFT JOIN IRIS_SITE_STATS iss
+					ON sour.SNO = iss.SNO
+					AND iss.START_DATE <= :1
+					AND iss.END_DATE >= :2
+					AND iss.IS_USE = 'Y'
+			) A
+			WHERE
+				1 = 1`
+
+	if err := db.SelectContext(ctx, &siteSqls, sql, targetDate, targetDate); err != nil {
+		return &siteSqls, fmt.Errorf("getSiteList fail: %w", err)
+	}
+
+	return &siteSqls, nil
+}

--- a/csm-api/store/store_site_date.go
+++ b/csm-api/store/store_site_date.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+func (r *Repository) GetSiteDateData(ctx context.Context, db Queryer, sno int64) (*entity.SiteDateSql, error) {
+	siteDateSql := entity.SiteDateSql{}
+
+	query := `SELECT
+				t1.OPENING_DATE,
+				t1.CLOSING_PLAN_DATE,
+				t1.CLOSING_FORECAST_DATE,
+				t1.CLOSING_ACTUAL_DATE,
+				t1.REG_UNO,
+				t1.REG_USER,
+				t1.REG_DATE
+			FROM
+				IRIS_SITE_DATE t1
+			WHERE
+				t1.SNO = :1
+				AND t1.IS_USE = 'Y'`
+
+	if err := db.GetContext(ctx, &siteDateSql, query, sno); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &siteDateSql, nil
+		}
+		return nil, fmt.Errorf("GetSiteDateData fail: %w", err)
+	}
+	return &siteDateSql, nil
+}

--- a/csm-api/store/store_site_pos.go
+++ b/csm-api/store/store_site_pos.go
@@ -1,0 +1,42 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+func (r *Repository) GetSitePosData(ctx context.Context, db Queryer, sno int64) (*entity.SitePosSql, error) {
+	sitePosSql := entity.SitePosSql{}
+
+	query := `SELECT
+				t1.ADDRESS_NAME_DEPTH1,
+				t1.ADDRESS_NAME_DEPTH2,
+				t1.ADDRESS_NAME_DEPTH3,
+				t1.ADDRESS_NAME_DEPTH4,
+				t1.ADDRESS_NAME_DEPTH5,
+				t1.ROAD_ADDRESS_NAME_DEPTH1,
+				t1.ROAD_ADDRESS_NAME_DEPTH2,
+				t1.ROAD_ADDRESS_NAME_DEPTH3,
+				t1.ROAD_ADDRESS_NAME_DEPTH4,
+				t1.ROAD_ADDRESS_NAME_DEPTH5,
+				t1.LATITUDE,
+				t1.LONGITUDE,
+				t1.REG_DATE
+			FROM
+				IRIS_SITE_POS t1
+			WHERE
+				t1.SNO = :1
+				AND t1.IS_USE = 'Y'`
+
+	if err := db.GetContext(ctx, &sitePosSql, query, sno); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return &sitePosSql, nil
+		}
+		return nil, fmt.Errorf("GetSitePosData fail: %v", err)
+	}
+
+	return &sitePosSql, nil
+}

--- a/csm-api/store/store_user.go
+++ b/csm-api/store/store_user.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"fmt"
+)
+
+func (r *Repository) GetUserInfoPmPeList(ctx context.Context, db Queryer, unoList []int) (*entity.UserPmPeInfoSqls, error) {
+	userPmPeInfoSqls := entity.UserPmPeInfoSqls{}
+
+	sql := `SELECT
+    			t1.UNO,
+    			t1.USER_ID,
+    			t1.USER_NAME
+			FROM COMMON.V_BIZ_USER_INFO t1
+			WHERE t1.UNO IN (:1)`
+
+	if err := db.SelectContext(ctx, &userPmPeInfoSqls, sql, unoList); err != nil {
+		return nil, fmt.Errorf("GetUserInfoPmPeList fail: %w", err)
+	}
+
+	return &userPmPeInfoSqls, nil
+}


### PR DESCRIPTION
여러 테이블을 조회하고 조합하여 리스트를 출력

- entity: db 및 reponse struct 정의 db에서 null을 반환하게 되면 go에서는 기본타입들은 null을 처리할 수 없기 때문에 오류가 발생한다. 그렇기에 sql.Null- 접두사가 붙은 타입을 사용해서 db처리를 하고 그 후에 일반struct로 변환하여 사용한다.

struct명칭에
    -s 라는 접미사가 있으면 해당 struct의 배열
    -Sql 라는 접미사가 있으면 해당 struct의 db전용
struct의 func에
    To- 라는 접두사가 있으면 파라미터로 다른 struct를 받아서 해당 struct로 변환

- handler: http handler를 정의하여 비즈니스가 실행될 수 있게 하는 장소

- service: db함수 호출 및 데이터 전후 처리 api 호출 후 들어오거나 나가는 모든 데이터에 대한 처리를 하고 db 함수를 호출하거나 다른 함수를 사용하는 장소

- store: db처리 오로지 db를 처리하기 위한 장소로써, 데이터에 대한 처리 작업은 store가 아닌 service에서 이루어져야 함.