### PR TITLE
 jwt의 claim 정보에 uno 값 넣기

### DIFF
--- a/csm-api/auth/jwtUtils.go
+++ b/csm-api/auth/jwtUtils.go
@@ -5,9 +5,10 @@ import (
 	"csm-api/clock"
 	"csm-api/config"
 	"fmt"
-	"github.com/golang-jwt/jwt/v5"
 	"net/http"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type JWTUtils struct {
@@ -24,6 +25,7 @@ const (
 
 // claims 정의
 type JWTClaims struct {
+	Uno      int64   `json:"uno"`
 	UserId   string  `json:"user_id"`
 	UserName string  `json:"user_name"`
 	Role     JWTRole `json:"role"`
@@ -62,6 +64,7 @@ func (j *JWTUtils) GenerateToken(jwtClaims *JWTClaims) (string, error) {
 
 	// JWT 클레임 설정
 	claims := jwt.MapClaims{
+		"uno":      jwtClaims.Uno,
 		"userId":   jwtClaims.UserId,
 		"userName": jwtClaims.UserName,
 		"role":     jwtClaims.Role,
@@ -126,6 +129,7 @@ func (j *JWTUtils) ValidateJWT(r *http.Request) (*JWTClaims, error) {
 
 	// JWTClaims 매핑
 	jwtClaims := &JWTClaims{
+		Uno:      int64(claims["uno"].(float64)),
 		UserId:   claims["userId"].(string),
 		UserName: claims["userName"].(string),
 		IsSaved:  claims["isSaved"].(bool), // "아이디 저장" 여부 확인

--- a/csm-api/entity/user.go
+++ b/csm-api/entity/user.go
@@ -3,6 +3,7 @@ package entity
 import "database/sql"
 
 type User struct {
+	Uno      int64  `json:"uno" db:"UNO"`
 	UserId   string `json:"user_id" db:"USER_ID"`
 	UserName string `json:"user_name" db:"USER_NAME"`
 	UserPwd  string `json:"user_pwd" db:"USER_PWD"`

--- a/csm-api/handler/handler_login.go
+++ b/csm-api/handler/handler_login.go
@@ -51,7 +51,7 @@ func (l *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	//jwt 생성
-	tokenString, err := l.Jwt.GenerateToken(&auth.JWTClaims{UserId: user.UserId, UserName: user.UserName, IsSaved: login.IsSaved})
+	tokenString, err := l.Jwt.GenerateToken(&auth.JWTClaims{Uno: user.Uno, UserId: user.UserId, UserName: user.UserName, IsSaved: login.IsSaved})
 	if err != nil {
 		RespondJSON(
 			ctx,

--- a/csm-api/store/store_device.go
+++ b/csm-api/store/store_device.go
@@ -25,7 +25,7 @@ import (
 func (r *Repository) GetDeviceList(ctx context.Context, db Queryer, page entity.PageSql, search entity.DeviceSql) (*entity.DeviceSqls, error) {
 	sqls := entity.DeviceSqls{}
 
-	condition := "1=1"
+	condition := "AND 1=1"
 	if search.DeviceNm.Valid {
 		trimDeviceNm := strings.TrimSpace(search.DeviceNm.String)
 
@@ -42,7 +42,7 @@ func (r *Repository) GetDeviceList(ctx context.Context, db Queryer, page entity.
 	}
 	if search.SiteNm.Valid {
 		trimSiteNm := strings.TrimSpace(search.SiteNm.String)
-		fmt.Print(trimSiteNm)
+
 		if trimSiteNm != "" {
 			condition += fmt.Sprintf(` AND LOWER(t2.SITE_NM) LIKE LOWER('%%%s%%')`, trimSiteNm)
 		}
@@ -90,6 +90,7 @@ func (r *Repository) GetDeviceList(ctx context.Context, db Queryer, page entity.
 						ON 
 							t1.SNO = t2.SNO
  						WHERE 
+							t1.SNO > 100
 							%s
 						ORDER BY 
 							%s
@@ -111,7 +112,7 @@ func (r *Repository) GetDeviceList(ctx context.Context, db Queryer, page entity.
 func (r *Repository) GetDeviceListCount(ctx context.Context, db Queryer, search entity.DeviceSql) (int, error) {
 	var count int
 
-	condition := "1=1"
+	condition := "AND 1=1"
 	if search.DeviceNm.Valid {
 		trimDeviceNm := strings.TrimSpace(search.DeviceNm.String)
 
@@ -158,6 +159,7 @@ func (r *Repository) GetDeviceListCount(ctx context.Context, db Queryer, search 
 				ON 
 					t1.SNO = t2.SNO
 				WHERE 
+					t1.SNO > 100
 					%s`, condition)
 
 	if err := db.GetContext(ctx, &count, query); err != nil {

--- a/csm-api/store/store_notice.go
+++ b/csm-api/store/store_notice.go
@@ -25,7 +25,7 @@ func (r *Repository) GetNoticeList(ctx context.Context, db Queryer, page entity.
 	sqls := entity.NoticeSqls{}
 
 	// 조건
-	condition := "n1.IS_USE = 'Y'"
+	condition := "AND 1=1"
 	if search.LocCode.Valid {
 		trimLocCode := strings.TrimSpace(search.LocCode.String)
 
@@ -81,7 +81,8 @@ func (r *Repository) GetNoticeList(ctx context.Context, db Queryer, page entity.
 							IRIS_NOTICE_BOARD n1 LEFT OUTER JOIN IRIS_SITE_SET n2 
 						ON 
 							n1.SNO = n2.SNO
-						WHERE 
+						WHERE
+							n1.IS_USE = 'Y' 
 							%s
 						ORDER BY
 							%s
@@ -105,7 +106,7 @@ func (r *Repository) GetNoticeList(ctx context.Context, db Queryer, page entity.
 func (r *Repository) GetNoticeListCount(ctx context.Context, db Queryer, search entity.NoticeSql) (int, error) {
 	var count int
 
-	condition := "n1.IS_USE = 'Y'"
+	condition := "AND 1=1"
 	if search.LocCode.Valid {
 		trimLocCode := strings.TrimSpace(search.LocCode.String)
 
@@ -138,7 +139,9 @@ func (r *Repository) GetNoticeListCount(ctx context.Context, db Queryer, search 
 				IRIS_NOTICE_BOARD n1 LEFT OUTER JOIN IRIS_SITE_SET n2 
 			ON 
 				n1.SNO = n2.SNO 
-			WHERE %s`, condition)
+			WHERE
+				n1.IS_USE = 'Y' 
+				%s`, condition)
 
 	if err := db.GetContext(ctx, &count, query); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/csm-api/store/user_valid.go
+++ b/csm-api/store/user_valid.go
@@ -10,6 +10,7 @@ func (r *Repository) GetUserValid(ctx context.Context, db Queryer, userId string
 	user := entity.User{}
 
 	sql := `SELECT
+			t1.UNO,
 		    t1.USER_ID,
 			t1.USER_NAME
 		FROM


### PR DESCRIPTION
1. jwt의 claim 정보에 uno 값 넣기.
    - jwtUtils에서 JWTClaims에 매핑 시, claims["uno"].(int64)로 할 경우 에러가 발생하여 int64(claims["uno"].(float64)) 형식으로 매핑

2. store_device.go에 SNO(장소)가 100이상으로 변경.