### PR TITLE
리팩토링 참고 코드

### DIFF
--- a/csm-api/entity/base.go
+++ b/csm-api/entity/base.go
@@ -1,0 +1,14 @@
+package entity
+
+import "github.com/guregu/null"
+
+type Base struct {
+	RegUser  null.String `json:"reg_user" db:"REG_USER"`
+	RegAgent null.String `json:"reg_agent" db:"REG_AGENT"`
+	RegUno   null.Int    `json:"reg_uno" db:"REG_UNO"`
+	RegDate  null.Time   `json:"reg_date" db:"REG_DATE"`
+	ModUser  null.String `json:"mod_user" db:"MOD_USER"`
+	ModAgent null.String `json:"mod_agent" db:"MOD_AGENT"`
+	ModUno   null.Int    `json:"mod_uno" db:"MOD_UNO"`
+	ModDate  null.Time   `json:"mod_date" db:"MOD_DATE"`
+}

--- a/csm-api/entity/equip.go
+++ b/csm-api/entity/equip.go
@@ -1,0 +1,13 @@
+package entity
+
+import "github.com/guregu/null"
+
+type EquipTemp struct {
+	Sno        null.Int  `json:"sno" db:"SNO"`
+	Jno        null.Int  `json:"jno" db:"JNO"`
+	Cnt        null.Int  `json:"cnt" db:"CNT"`
+	RecordDate null.Time `json:"record_date" db:"RECORD_DATE"`
+	Base
+}
+
+type EquipTemps []*EquipTemp

--- a/csm-api/go.mod
+++ b/csm-api/go.mod
@@ -15,6 +15,7 @@ require (
 require (
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/godror/knownpb v0.2.0 // indirect
+	github.com/guregu/null v4.0.0+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.0 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	google.golang.org/protobuf v1.36.2 // indirect

--- a/csm-api/go.sum
+++ b/csm-api/go.sum
@@ -22,6 +22,8 @@ github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17w
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/guregu/null v4.0.0+incompatible h1:4zw0ckM7ECd6FNNddc3Fu4aty9nTlpkkzH7dPn4/4Gw=
+github.com/guregu/null v4.0.0+incompatible/go.mod h1:ePGpQaN9cw0tj45IR5E5ehMvsFlLlQZAkkOXZurJ3NM=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=

--- a/csm-api/handler/handler_equip.go
+++ b/csm-api/handler/handler_equip.go
@@ -1,0 +1,50 @@
+package handler
+
+import (
+	"csm-api/entity"
+	"csm-api/service"
+	"encoding/json"
+	"net/http"
+)
+
+type HandlerEquip struct {
+	Service service.EquipService
+}
+
+func (h *HandlerEquip) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	equips := entity.EquipTemps{}
+
+	if err := json.NewDecoder(r.Body).Decode(&equips); err != nil {
+		RespondJSON(
+			ctx,
+			w,
+			&ErrResponse{
+				Result:         Failure,
+				Message:        err.Error(),
+				HttpStatusCode: http.StatusInternalServerError,
+			},
+			http.StatusOK)
+		return
+	}
+
+	if err := h.Service.MergeEquipCnt(ctx, equips); err != nil {
+		RespondJSON(
+			ctx,
+			w,
+			&ErrResponse{
+				Result:         Failure,
+				Message:        err.Error(),
+				HttpStatusCode: http.StatusInternalServerError,
+			},
+			http.StatusOK)
+		return
+	}
+
+	rsp := Response{
+		Result: Success,
+	}
+
+	RespondJSON(ctx, w, &rsp, http.StatusOK)
+}

--- a/csm-api/handler/response.go
+++ b/csm-api/handler/response.go
@@ -62,7 +62,7 @@ func RespondJSON(ctx context.Context, w http.ResponseWriter, body any, status in
 	}
 
 	w.WriteHeader(status)
-	if _, err := fmt.Fprintf(w, "%s", bodyBytes); err != nil {
+	if _, err = fmt.Fprintf(w, "%s", bodyBytes); err != nil {
 		fmt.Printf("write response error: %v", err)
 	}
 }

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -537,6 +537,21 @@ func newMux(ctx context.Context, cfg *config.DBConfigs) (http.Handler, []func(),
 	})
 	// End::공지사항
 
+	// Begin::장비
+	equipMergeHandler := &handler.HandlerEquip{
+		Service: &service.ServiceEquip{
+			TDB:   safeDb,
+			Store: &r,
+		},
+	}
+
+	mux.Route("/equip", func(r chi.Router) {
+		//r.Use(handler.AuthMiddleware(jwt))
+		r.Post("/temp", equipMergeHandler.ServeHTTP)
+	})
+
+	// End::장비
+
 	// 라우팅:: end
 
 	handlerMux := c.Handler(mux)

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -109,3 +109,7 @@ type AddressSearchAPIService interface {
 	GetAPILatitudeLongtitude(roadAddress string) (*entity.Point, error)
 	GetAPISiteMapPoint(roadAddress string) (*entity.MapPoint, error)
 }
+
+type EquipService interface {
+	MergeEquipCnt(ctx context.Context, equips entity.EquipTemps) error
+}

--- a/csm-api/service/service_equip.go
+++ b/csm-api/service/service_equip.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+)
+
+type ServiceEquip struct {
+	DB    store.Queryer
+	TDB   store.Beginner
+	Store store.EquipStore
+}
+
+func (s *ServiceEquip) MergeEquipCnt(ctx context.Context, equips entity.EquipTemps) error {
+	if err := s.Store.MergeEquipCnt(ctx, s.TDB, equips); err != nil {
+		//TODO: 에러 아카이브
+		return fmt.Errorf("service;MergeEquipCnt failed: %v", err)
+	}
+	return nil
+}

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -104,3 +104,7 @@ type CompanyStore interface {
 	GetCompanyInfoList(ctx context.Context, db Queryer, jno sql.NullInt64) (*entity.CompanyInfoSqls, error)
 	GetCompanyWorkInfoList(ctx context.Context, db Queryer, jno sql.NullInt64) (*entity.WorkInfosqls, error)
 }
+
+type EquipStore interface {
+	MergeEquipCnt(ctx context.Context, db Beginner, equips entity.EquipTemps) error
+}

--- a/csm-api/store/store_equip.go
+++ b/csm-api/store/store_equip.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"fmt"
+)
+
+func (r *Repository) MergeEquipCnt(ctx context.Context, db Beginner, equips entity.EquipTemps) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		//TODO: 에러 아카이브
+		return fmt.Errorf("MergeEquipCnt BeginTx fail: %v", err)
+	}
+
+	query := `
+			MERGE INTO IRIS_EQUIP_TEMP T1
+			USING(
+				SELECT
+					:1 AS SNO,
+					:2 AS JNO,
+					:3 AS CNT,
+					TRUNC(SYSDATE) AS RECORD_DATE,
+				    :4 AS REG_USER
+				FROM DUAL
+			) T2 
+			ON (
+				T1.SNO = T2.SNO
+				AND T1.JNO = T2.JNO
+				AND T1.RECORD_DATE = T2.RECORD_DATE
+			)
+			WHEN MATCHED THEN
+				UPDATE SET
+					T1.CNT = T2.CNT,
+			    	T1.REG_USER = T2.REG_USER
+				WHERE T1.SNO = T2.SNO
+				AND T1.JNO = T2.JNO
+				AND T1.RECORD_DATE = T2.RECORD_DATE
+			WHEN NOT MATCHED THEN
+				INSERT (SNO, JNO, CNT, RECORD_DATE, REG_USER)
+				VALUES (T2.SNO, T2.JNO, T2.CNT, T2.RECORD_DATE, T2.REG_USER)`
+
+	for _, equip := range equips {
+		if _, err = tx.QueryContext(ctx, query, equip.Sno, equip.Jno, equip.Cnt, equip.RegUser); err != nil {
+			origErr := err
+			err = tx.Rollback()
+			if err != nil {
+				//TODO: 에러 아카이브 처리
+				return fmt.Errorf("MergeEquipCnt Rollback fail: %v\n", err)
+			}
+			//TODO: 에러 아카이브
+			return fmt.Errorf("MergeEquipCnt QueryContext fail: %v", origErr)
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		//TODO: 에러 아카이브
+		return fmt.Errorf("MergeEquipCnt Commit fail: %v\n", err)
+	}
+	return nil
+}


### PR DESCRIPTION
1. json과 db의 구조체를 다르게 써야 하다보니 불필요한 코드가 많아지기 때문에 서드파티라이브러리를 이용하여 코드량을 줄이려고 함.
2. 익명필드임베딩을 하여 작성자,수정자 필드를 공통으로 관리할 수 있도록 변경