### PR TITLE
서비스, 스토어 레이어 리팩토링

### DIFF
--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -219,9 +219,9 @@ func newMux(ctx context.Context, cfg *config.DBConfigs) (http.Handler, []func(),
 	// Begin::근태인식기
 	deviceHandler := &handler.DeviceHandler{
 		Service: &service.ServiceDevice{
-			DB:    safeDb,
-			TDB:   safeDb,
-			Store: &r,
+			SafeQueryer:  safeDb,
+			SafeBeginner: safeDb,
+			Store:        &r,
 		},
 	}
 	mux.Route("/device", func(r chi.Router) {

--- a/csm-api/service/service_site.go
+++ b/csm-api/service/service_site.go
@@ -128,7 +128,6 @@ func (s *ServiceSite) GetSiteStatsList(ctx context.Context, targetDate time.Time
 // @param
 // -
 func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) error {
-
 	if site.Sno.Int64 == 0 {
 		//TODO: 에러 아카이브
 		return fmt.Errorf("sno parameter is missing")

--- a/csm-api/store/repository.go
+++ b/csm-api/store/repository.go
@@ -60,6 +60,9 @@ type Preparer interface {
 
 type Execer interface {
 	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
+}
+
+type NamedExecer interface {
 	NamedExecContext(ctx context.Context, query string, arg interface{}) (sql.Result, error)
 }
 

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -79,9 +79,9 @@ type NoticeStore interface {
 type DeviceStore interface {
 	GetDeviceList(ctx context.Context, db Queryer, page entity.PageSql, search entity.Device, retry string) (*entity.Devices, error)
 	GetDeviceListCount(ctx context.Context, db Queryer, search entity.Device, retry string) (int, error)
-	AddDevice(ctx context.Context, db Beginner, device entity.Device) error
-	ModifyDevice(ctx context.Context, db Beginner, device entity.Device) error
-	RemoveDevice(ctx context.Context, db Beginner, dno sql.NullInt64) error
+	AddDevice(ctx context.Context, tx Execer, device entity.Device) error
+	ModifyDevice(ctx context.Context, tx Execer, device entity.Device) error
+	RemoveDevice(ctx context.Context, tx Execer, dno sql.NullInt64) error
 }
 
 type WorkerStore interface {

--- a/csm-api/store/store_site.go
+++ b/csm-api/store/store_site.go
@@ -45,16 +45,11 @@ func (r *Repository) GetSiteList(ctx context.Context, db Queryer, targetDate tim
 				END AS CURRENT_SITE_STATS
 			FROM
 				IRIS_SITE_SET t1
-				INNER JOIN IRIS_SITE_JOB t2 
-					ON t1.SNO = t2.SNO 
-					AND t2.IS_DEFAULT = 'Y'
-				INNER JOIN S_JOB_INFO t3 
-					ON t2.JNO = t3.JNO
-				LEFT JOIN IRIS_RECD_SET t4
-					ON t1.SNO = t4.SNO
-					AND TO_CHAR(t4.RECOG_TIME, 'YYYY-MM-DD') = TO_CHAR(:1, 'YYYY-MM-DD')
-			WHERE
-				t1.SNO > 100
+				INNER JOIN IRIS_SITE_JOB t2 ON t1.SNO = t2.SNO AND t2.IS_DEFAULT = 'Y'
+				INNER JOIN S_JOB_INFO t3 ON t2.JNO = t3.JNO
+				LEFT JOIN IRIS_RECD_SET t4 ON t1.SNO = t4.SNO AND TO_CHAR(t4.RECOG_TIME, 'YYYY-MM-DD') = TO_CHAR(:1, 'YYYY-MM-DD')
+			WHERE t1.SNO > 100
+			AND t1.IS_USE = 'Y'
 			GROUP BY
 				t1.SNO,
 				t2.JNO,


### PR DESCRIPTION
현재 작성된 것은 트랙잭션을 서비스 레이어가 아닌 스토어 레이어에서 하고 있다
이렇게 된다면 서비스 레이어에서 여러 스토어 함수를 불러올 경우에 하나가 실패했지만 실패한 스토어함수 외에는 롤백이 되지 않고 커밋이 되는 상황이 발생이 된다. 그걸 방지하기 위하여 서비스 레이어에서 트랜잭션을 생성하여 관리를 할 수 있게 하고
defer를 사용하여 마지막에 롤백/커밋을 할 수 있도록 하였다