### PR TITLE
날씨 조회 api 수정

### DIFF
--- a/csm-api/entity/site_pos.go
+++ b/csm-api/entity/site_pos.go
@@ -5,6 +5,7 @@ import (
 )
 
 type SitePos struct {
+	Sno                   null.Int    `json:"sno" db:"SNO"`
 	AddressNameDepth1     null.String `json:"address_name_depth1" db:"ADDRESS_NAME_DEPTH1"`
 	AddressNameDepth2     null.String `json:"address_name_depth2" db:"ADDRESS_NAME_DEPTH2"`
 	AddressNameDepth3     null.String `json:"address_name_depth3" db:"ADDRESS_NAME_DEPTH3"`

--- a/csm-api/entity/whether.go
+++ b/csm-api/entity/whether.go
@@ -48,6 +48,12 @@ type WhetherSrtEntity struct {
 }
 type WhetherSrtEntityRes []WhetherSrtEntity
 
+type WhetherSrt struct {
+	Whether WhetherSrtEntityRes `json:"whether"`
+	Sno     int64               `json:"sno"`
+}
+type WhetherSrtRes []WhetherSrt
+
 // func: 풍향 변환 숫자 -> 한글
 // @param
 // - value: 풍향(방위)

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -163,6 +163,10 @@ func newMux(ctx context.Context, cfg *config.DBConfigs) (http.Handler, []func(),
 		Service: &service.ServiceWhether{
 			ApiKey: apiCfg,
 		},
+		SitePosService: &service.ServiceSitePos{
+			DB:    safeDb,
+			Store: &r,
+		},
 	}
 
 	// 기상청 기상특보통보문 조회

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -21,6 +21,7 @@ type SiteService interface {
 }
 
 type SitePosService interface {
+	GetSitePosList(ctx context.Context) ([]entity.SitePos, error)
 	GetSitePosData(ctx context.Context, sno int64) (*entity.SitePos, error)
 	ModifySitePos(ctx context.Context, sno int64, sitePos entity.SitePos) error
 }

--- a/csm-api/service/service_site.go
+++ b/csm-api/service/service_site.go
@@ -86,17 +86,17 @@ func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*e
 		site.SitePos = sitePos
 
 		// 현장 날씨 조회
-		now := time.Now()
-		baseDate := now.Format("20060102")
-		baseTime := now.Add(time.Minute * -30).Format("1504") // 기상청에서 30분 단위로 발표하기 때문에 30분 전의 데이터 요청
-		nx, ny := utils.LatLonToXY(sitePos.Latitude.Float64, sitePos.Longitude.Float64)
-
-		siteWhether, err := s.WhetherApiService.GetWhetherSrtNcst(baseDate, baseTime, nx, ny)
-		if err != nil {
-			//TODO: 에러 아카이브
-			return &entity.Sites{}, fmt.Errorf("service_site/GetWhetherSrt err: %w", err)
-		}
-		site.Whether = siteWhether
+		//now := time.Now()
+		//baseDate := now.Format("20060102")
+		//baseTime := now.Add(time.Minute * -30).Format("1504") // 기상청에서 30분 단위로 발표하기 때문에 30분 전의 데이터 요청
+		//nx, ny := utils.LatLonToXY(sitePos.Latitude.Float64, sitePos.Longitude.Float64)
+		//
+		//siteWhether, err := s.WhetherApiService.GetWhetherSrtNcst(baseDate, baseTime, nx, ny)
+		//if err != nil {
+		//	//TODO: 에러 아카이브
+		//	return &entity.Sites{}, fmt.Errorf("service_site/GetWhetherSrt err: %w", err)
+		//}
+		//site.Whether = siteWhether
 
 		// 현장 날짜 조회
 		siteDateData, err := s.SiteDateStore.GetSiteDateData(ctx, s.SafeDB, sno)

--- a/csm-api/service/service_site_pos.go
+++ b/csm-api/service/service_site_pos.go
@@ -15,6 +15,14 @@ type ServiceSitePos struct {
 	Store store.SitePosStore
 }
 
+func (s *ServiceSitePos) GetSitePosList(ctx context.Context) ([]entity.SitePos, error) {
+	list, err := s.Store.GetSitePosList(ctx, s.DB)
+	if err != nil {
+		return nil, fmt.Errorf("service;GetSitePosList: %w", err)
+	}
+	return list, nil
+}
+
 // 현장 위치 테이블 조회
 //
 // @param sno: 현장 고유번호

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -22,6 +22,7 @@ type SiteStore interface {
 }
 
 type SitePosStore interface {
+	GetSitePosList(ctx context.Context, db Queryer) ([]entity.SitePos, error)
 	GetSitePosData(ctx context.Context, db Queryer, sno int64) (*entity.SitePos, error)
 	ModifySitePosData(ctx context.Context, tx Execer, sno int64, sitePosSql entity.SitePos) error
 	ModifySitePosIsNonUse(ctx context.Context, tx Execer, sno int64) error

--- a/csm-api/store/store_site_pos.go
+++ b/csm-api/store/store_site_pos.go
@@ -8,6 +8,34 @@ import (
 	"fmt"
 )
 
+func (r *Repository) GetSitePosList(ctx context.Context, db Queryer) ([]entity.SitePos, error) {
+	var list []entity.SitePos
+
+	query := `SELECT
+    			t1.SNO,
+				t1.ADDRESS_NAME_DEPTH1,
+				t1.ADDRESS_NAME_DEPTH2,
+				t1.ADDRESS_NAME_DEPTH3,
+				t1.ADDRESS_NAME_DEPTH4,
+				t1.ADDRESS_NAME_DEPTH5,
+				t1.ROAD_ADDRESS_NAME_DEPTH1,
+				t1.ROAD_ADDRESS_NAME_DEPTH2,
+				t1.ROAD_ADDRESS_NAME_DEPTH3,
+				t1.ROAD_ADDRESS_NAME_DEPTH4,
+				t1.ROAD_ADDRESS_NAME_DEPTH5,
+				t1.LATITUDE,
+				t1.LONGITUDE,
+				t1.REG_DATE
+			FROM
+				IRIS_SITE_POS t1
+			WHERE t1.IS_USE = 'Y'`
+
+	if err := db.SelectContext(ctx, &list, query); err != nil {
+		return nil, fmt.Errorf("GetSitePosList fail: %w", err)
+	}
+	return list, nil
+}
+
 func (r *Repository) GetSitePosData(ctx context.Context, db Queryer, sno int64) (*entity.SitePos, error) {
 	sitePos := entity.SitePos{}
 


### PR DESCRIPTION
기존에 현장service 내부에 날씨api가 사용되었는데 이렇게 하다보니 간혹 api조회시간이 너무 길어질 경우에 front의 현장관리 화면이 멈추는 경우가 있어서 수정을 하게 됨. 현장 service에서 날씨를 조회하지 않고 날씨조회하는 api를 새롭게 만들었음