### PR TITLE
init, scheduler 작성 및 코드 리팩토링

### DIFF
--- a/csm-api/go.mod
+++ b/csm-api/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/godror/knownpb v0.2.0 // indirect
 	github.com/guregu/null v4.0.0+incompatible // indirect
 	github.com/planetscale/vtprotobuf v0.6.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8 // indirect
 	google.golang.org/protobuf v1.36.2 // indirect
 )

--- a/csm-api/go.sum
+++ b/csm-api/go.sum
@@ -36,6 +36,8 @@ github.com/planetscale/vtprotobuf v0.6.0 h1:nBeETjudeJ5ZgBHUz1fVHvbqUKnYOXNhsIEa
 github.com/planetscale/vtprotobuf v0.6.0/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
 github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/csm-api/init.go
+++ b/csm-api/init.go
@@ -2,51 +2,49 @@ package main
 
 import (
 	"context"
-	"csm-api/config"
+	"csm-api/clock"
 	"csm-api/service"
 	"csm-api/store"
 	"fmt"
+	"github.com/jmoiron/sqlx"
 	"golang.org/x/sync/errgroup"
-	"time"
+	"log"
 )
 
+/**
+ * @author 작성자: 김진우
+ * @created 작성일: 2025-04-28
+ * @modified 최종 수정일:
+ * @modifiedBy 최종 수정자:
+ * @description: 서버 실행시 초기화를 위한 설정
+ * - 현장 근로자 마감처리 (당일 이전 날짜 중에서 퇴근을 한 근로자들만 마감처리)
+ */
 type Init struct {
-	Service service.RestDateApiService
+	WorkerService service.WorkerService
 }
 
-func (i *Init) New() (*Init, error) {
-	apiCfg, err := config.GetApiConfig()
-	if err != nil {
-		return nil, err
+func NewInit(safeDb *sqlx.DB) (*Init, error) {
+	r := store.Repository{Clocker: clock.RealClock{}}
+
+	init := &Init{
+		WorkerService: &service.ServiceWorker{
+			SafeDB:  safeDb,
+			SafeTDB: safeDb,
+			Store:   &r,
+		},
 	}
 
-	return &Init{
-		Service: &service.ServiceRestDate{
-			ApiKey: apiCfg,
-		},
-	}, err
+	return init, nil
 }
 
-func (i *Init) RunInitializations(ctx context.Context, cfg *config.DBConfigs) (err error) {
+func (i *Init) RunInitializations(ctx context.Context) (err error) {
 	eg, ctx := errgroup.WithContext(ctx)
 
-	_, safeCleanup, safeErr := store.New(ctx, cfg.Safe)
-	if safeErr != nil {
-		safeCleanup()
-		return fmt.Errorf("store.New: %w", safeErr)
-	}
-
-	defer func() {
-		if err != nil {
-			safeCleanup()
-		}
-	}()
-
 	eg.Go(func() error {
-		fmt.Println("[init] restDelInfo API call & db save")
-
-		time.Sleep(2 * time.Second) // 2초 대기
-
+		if err = i.WorkerService.ModifyWorkerDeadlineInit(ctx); err != nil {
+			return fmt.Errorf("[init] RunInitializations fail: %w", err)
+		}
+		log.Println("[init] ModifyWorkerDeadlineInit completed")
 		return nil
 	})
 

--- a/csm-api/main.go
+++ b/csm-api/main.go
@@ -3,8 +3,15 @@ package main
 import (
 	"context"
 	"csm-api/config"
+	"csm-api/store"
 	"fmt"
+	"golang.org/x/sync/errgroup"
+	"log"
 	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 )
 
 func main() {
@@ -14,7 +21,11 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	// port 환경변수
+	// 시스템 종료 신호 받을 수 있게 context 세팅
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	// config 설정
 	cfg, err := config.NewConfig()
 	if err != nil {
 		return fmt.Errorf("config.NewConfig: %w", err)
@@ -29,24 +40,83 @@ func run(ctx context.Context) error {
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	fmt.Printf("Listening at %s\n", url)
 
-	// db 환경변수
+	// DB config 설정
 	dbCfg, err := config.NewDBConfig()
 	if err != nil {
 		return fmt.Errorf("config.NewDBConfig: %w", err)
 	}
 
-	// 라우팅 설정
-	mux, cleanup, err := newMux(ctx, dbCfg)
+	// DB connect
+	var cleanup []func()
+	safeDb, safeCleanup, err := store.New(ctx, dbCfg.Safe)
+	if err != nil {
+		return fmt.Errorf("store.New (safeDb): %w", err)
+	}
+	cleanup = append(cleanup, func() { safeCleanup() })
+
+	timesheetDb, timesheetCleanup, err := store.New(ctx, dbCfg.TimeSheet)
+	if err != nil {
+		return fmt.Errorf("store.New (timesheetDb): %w", err)
+	}
+	cleanup = append(cleanup, func() { timesheetCleanup() })
+
 	defer func() {
 		for _, clean := range cleanup {
 			clean()
 		}
 	}()
+
+	// 초기화 (Init 객체 생성)
+	init, err := NewInit(safeDb)
+	if err != nil {
+		return fmt.Errorf("NewInit fail: %w", err)
+	}
+	// 초기화 실행
+	err = init.RunInitializations(ctx)
+	if err != nil {
+		return fmt.Errorf("RunInitializations fail: %w", err)
+	}
+
+	// 라우팅 설정
+	mux, err := newMux(ctx, safeDb, timesheetDb)
 	if err != nil {
 		return fmt.Errorf("newMux: %w", err)
 	}
 
-	// http 서버 생성 및 실행
+	// HTTP server 생성
 	server := NewServer(l, mux)
-	return server.Run(ctx)
+
+	// scheduler 생성
+	scheduler, err := NewScheduler(safeDb)
+	if err != nil {
+		return fmt.Errorf("NewScheduler fail: %w", err)
+	}
+
+	// 서버와 스케줄러 동시에 실행
+	eg, ctx := errgroup.WithContext(ctx)
+
+	eg.Go(func() error {
+		return server.Run(ctx)
+	})
+
+	eg.Go(func() error {
+		return scheduler.Run(ctx)
+	})
+
+	// 종료 신호 대기
+	select {
+	case <-ctx.Done():
+		fmt.Println("\nShutdown signal received")
+
+		// 서버 shutdown (5초 안에 처리)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err = server.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("server graceful shutdown failed: %w", err)
+		}
+		log.Println("Server exited normally.")
+	}
+
+	return nil
 }

--- a/csm-api/scheduler.go
+++ b/csm-api/scheduler.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"csm-api/clock"
+	"csm-api/service"
+	"csm-api/store"
+	"fmt"
+	"github.com/jmoiron/sqlx"
+	"github.com/robfig/cron/v3"
+	"log"
+)
+
+/**
+ * @author 작성자: 김진우
+ * @created 작성일: 2025-04-28
+ * @modified 최종 수정일:
+ * @modifiedBy 최종 수정자:
+ * @description: 스캐줄러 설정
+ * -
+ */
+
+type Scheduler struct {
+	WorkerService service.WorkerService
+	cron          *cron.Cron
+}
+
+func NewScheduler(safeDb *sqlx.DB) (*Scheduler, error) {
+	r := store.Repository{Clocker: clock.RealClock{}}
+	c := cron.New(cron.WithSeconds())
+
+	scheduler := &Scheduler{
+		WorkerService: &service.ServiceWorker{
+			SafeDB:  safeDb,
+			SafeTDB: safeDb,
+			Store:   &r,
+		},
+		cron: c,
+	}
+
+	return scheduler, nil
+}
+
+func (s *Scheduler) Run(ctx context.Context) error {
+	// 0시 0분 0초에 실행
+	// 근로자 마감 처리 (퇴근한 근로자만 처리)
+	_, err := s.cron.AddFunc("0 0 0 * * *", func() {
+		log.Println("[Scheduler] Running ModifyWorkerDeadlineSchedule")
+
+		if err := s.WorkerService.ModifyWorkerDeadlineInit(ctx); err != nil {
+			log.Printf("[Scheduler] ModifyWorkerDeadlineSchedule fail: %+v", err)
+		} else {
+			log.Println("[Scheduler] ModifyWorkerDeadlineSchedule completed")
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("[Scheduler] failed to add cron job: %w", err)
+	}
+
+	// ... 추가 job 등록
+
+	s.cron.Start()
+
+	log.Println("[Scheduler] Cron started")
+
+	// ctx.Done() 기다리다가 종료
+	<-ctx.Done()
+	log.Println("[Scheduler] Stopping scheduler...")
+
+	s.cron.Stop()
+	return nil
+}

--- a/csm-api/server.go
+++ b/csm-api/server.go
@@ -2,32 +2,34 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"golang.org/x/sync/errgroup"
 	"log"
 	"net"
 	"net/http"
+	"sync"
 )
 
 // http 서버를 실행하기 위한 struct
 type Server struct {
-	srv *http.Server
-	l   net.Listener
+	srv          *http.Server
+	l            net.Listener
+	shutdownOnce sync.Once
 }
 
 // Server struct에 담긴 값들을 바탕으로 실제 http서버를 고루틴을 이용하여 실행
 func (s *Server) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
+		log.Println("HTTP server starting...")
 		if err := s.srv.Serve(s.l); err != nil && err != http.ErrServerClosed {
 			log.Printf("failed to close: %+v", err)
-			return err
+			return fmt.Errorf("server error: %w", err)
 		}
+		log.Println("HTTP server closed normally.")
 		return nil
 	})
-	<-ctx.Done()
-	if err := s.srv.Shutdown(context.Background()); err != nil {
-		log.Printf("failed to shutdown: %+v", err)
-	}
+
 	return eg.Wait()
 }
 
@@ -37,4 +39,19 @@ func NewServer(l net.Listener, mux http.Handler) *Server {
 		srv: &http.Server{Handler: mux},
 		l:   l,
 	}
+}
+
+// 서버 종료
+func (s *Server) Shutdown(ctx context.Context) error {
+	var shutdownErr error
+	s.shutdownOnce.Do(func() {
+		log.Println("HTTP server shutdown initiated...")
+		if err := s.srv.Shutdown(ctx); err != nil {
+			log.Printf("HTTP server Shutdown error: %+v", err)
+			shutdownErr = err
+		} else {
+			log.Println("HTTP server shutdown completed gracefully.")
+		}
+	})
+	return shutdownErr
 }

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -105,6 +105,7 @@ type WorkerService interface {
 	MergeSiteBaseWorker(ctx context.Context, workers entity.WorkerDailys) error
 	ModifyWorkerDeadline(ctx context.Context, workers entity.WorkerDailys) error
 	ModifyWorkerProject(ctx context.Context, workers entity.WorkerDailys) error
+	ModifyWorkerDeadlineInit(ctx context.Context) error
 }
 
 type CompanyService interface {

--- a/csm-api/service/service_worker.go
+++ b/csm-api/service/service_worker.go
@@ -269,3 +269,30 @@ func (s *ServiceWorker) ModifyWorkerProject(ctx context.Context, workers entity.
 	}
 	return
 }
+
+// func: 현장 근로자 일일 마감처리
+// @param
+// -
+func (s *ServiceWorker) ModifyWorkerDeadlineInit(ctx context.Context) (err error) {
+	tx, err := s.SafeTDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("service_worker;ModifyWorkerDeadlineInit err: %v", err)
+	}
+
+	defer func() {
+		if err != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				err = fmt.Errorf("service_worker;ModifyWorker err: %v; rollback err: %v", err, rollbackErr)
+			}
+		} else {
+			if commitErr := tx.Commit(); commitErr != nil {
+				err = fmt.Errorf("service_worker;ModifyWorker err: %v; commit err: %v", err, commitErr)
+			}
+		}
+	}()
+
+	if err = s.Store.ModifyWorkerDeadlineInit(ctx, tx); err != nil {
+		return fmt.Errorf("service_worker/ModifyWorkerDeadlineInit err: %v", err)
+	}
+	return
+}

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -114,6 +114,7 @@ type WorkerStore interface {
 	MergeSiteBaseWorker(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyWorkerDeadline(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyWorkerProject(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	ModifyWorkerDeadlineInit(ctx context.Context, tx Execer) error
 }
 
 type CompanyStore interface {

--- a/csm-api/store/store_worker.go
+++ b/csm-api/store/store_worker.go
@@ -541,3 +541,28 @@ func (r *Repository) ModifyWorkerProject(ctx context.Context, tx Execer, workers
 
 	return nil
 }
+
+// func: 현장 근로자 일일 마감처리
+// @param
+// -
+func (r *Repository) ModifyWorkerDeadlineInit(ctx context.Context, tx Execer) error {
+	agent := utils.GetAgent()
+
+	query := `
+			UPDATE IRIS_WORKER_DAILY_SET 
+			SET 
+				IS_DEADLINE = 'Y',
+				MOD_DATE = SYSDATE,
+				MOD_AGENT = :1,
+				MOD_USER = 'Scheduled'
+			WHERE TRUNC(RECORD_DATE) >= TRUNC(SYSDATE) - 7
+			AND TRUNC(RECORD_DATE) < TRUNC(SYSDATE)
+			AND WORK_STATE = '02'
+			AND IS_DEADLINE = 'N'`
+
+	if _, err := tx.ExecContext(ctx, query, agent); err != nil {
+		return fmt.Errorf("ModifyWorkerDeadlineInit fail: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
1. 당일 이전의 근로자들을 마감처리하는 로직 작성 - 퇴근한 근로자만 변경
2. 현장근로자를 당일에만 수정이 가능하도록 자정에 마감처리를 하는 스케줄러 코드 작성
3. 서버가 내려가서 마감처리 스케줄이 정상적으로 작동 안했을 수 있기 때문에 서버 실행시 당일 이전 근로자 마감처리 하는 init 코드 작성
4. api server, init, scheduler 에서 각각 db connect를 하는 것은 비효율적이기에 main의 run에서 연결하여 사용하도록 수정