### PR TITLE
[현장근로자] 현장 근로자 철야처리

### DIFF
--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -46,3 +46,10 @@ type WorkerDaily struct {
 	Base
 }
 type WorkerDailys []*WorkerDaily
+
+type WorkerOverTime struct {
+	BeforeCno    null.Int  `json:"before_cno" db:"BEFORE_CNO"`         // 출근한 날 CNO
+	AfterCno     null.Int  `json:"after_cno" db:"AFTER_CNO"`           // 퇴근한 날 CNO
+	OutRecogTime null.Time `json:"out_recog_time" db:"OUT_RECOG_TIME"` // 퇴근시간
+}
+type WorkerOverTimes []*WorkerOverTime

--- a/csm-api/scheduler.go
+++ b/csm-api/scheduler.go
@@ -57,8 +57,25 @@ func (s *Scheduler) Run(ctx context.Context) error {
 		return fmt.Errorf("[Scheduler] failed to add cron job: %w", err)
 	}
 
-	// ... 추가 job 등록
+	// 1분마다 실행
+	// 철야 확인 작업
+	_, err = s.cron.AddFunc("0 0/1 * * * *", func() {
+		log.Println("[Scheduler] Running ModifyWorkerOverTimeSchedule")
 
+		if err = s.WorkerService.ModifyWorkerOverTime(ctx); err != nil {
+			log.Printf("[Scheduler] ModifyWorkerOverTime fail: %+v", err)
+		} else {
+			log.Println("[Scheduler] ModifyWorkerOverTime completed")
+		}
+
+	})
+	if err != nil {
+		// TODO: 에러아카이브
+		return fmt.Errorf("[Scheduler] failed to add cron job: %w", err)
+	}
+
+	// ... 추가 job 등록
+	
 	s.cron.Start()
 
 	log.Println("[Scheduler] Cron started")

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -106,6 +106,7 @@ type WorkerService interface {
 	ModifyWorkerDeadline(ctx context.Context, workers entity.WorkerDailys) error
 	ModifyWorkerProject(ctx context.Context, workers entity.WorkerDailys) error
 	ModifyWorkerDeadlineInit(ctx context.Context) error
+	ModifyWorkerOverTime(ctx context.Context) error
 }
 
 type CompanyService interface {

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -115,6 +115,9 @@ type WorkerStore interface {
 	ModifyWorkerDeadline(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyWorkerProject(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyWorkerDeadlineInit(ctx context.Context, tx Execer) error
+	GetWorkerOverTime(ctx context.Context, db Queryer) (*entity.WorkerOverTimes, error)
+	ModifyWorkerOverTime(ctx context.Context, tx Execer, workerOverTime entity.WorkerOverTime) error
+	DeleteWorkerOverTime(ctx context.Context, tx Execer, cno null.Int) error
 }
 
 type CompanyStore interface {


### PR DESCRIPTION
1. 현장 근로자 철야 schedule 등록
    - 1분마다 확인
    - 오늘을 기준으로 전날 출근만 있고, 오늘 퇴근만 있는 경우 확인

2. 철야인 경우(store: ModifyWorkerOverTime)
   - 철야필드 Y로 변경
   - 전날 퇴근시간에 퇴근시간 표기
   - 상태 퇴근으로 변경

3. 철야인 경우(store: DeleteWorkerOverTime)
   - 퇴근 기록 삭제