### PR TITLE
mux 라우팅 리팩토링

### DIFF
--- a/csm-api/handler/handler_site.go
+++ b/csm-api/handler/handler_site.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"csm-api/auth"
 	"csm-api/entity"
 	"csm-api/service"
 	"csm-api/utils"
@@ -23,7 +22,6 @@ import (
 type HandlerSite struct {
 	Service     service.SiteService
 	CodeService service.CodeService
-	Jwt         *auth.JWTUtils
 }
 
 // func: 현장 관리 리스트

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -6,7 +6,7 @@ import (
 	"csm-api/clock"
 	"csm-api/config"
 	"csm-api/handler"
-	"csm-api/service"
+	"csm-api/route"
 	"csm-api/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/jmoiron/sqlx"
@@ -51,303 +51,26 @@ func newMux(ctx context.Context, safeDb *sqlx.DB, timesheetDb *sqlx.DB) (http.Ha
 		return nil, err
 	}
 
-	// 라우팅:: begin
-	// 로그인
-	loginHandler := &handler.LoginHandler{
-		Service: &service.UserValid{
-			DB:    safeDb,
-			Store: &r,
-		},
-		Jwt: jwt,
-	}
-	mux.Post("/login", loginHandler.ServeHTTP)
-	// 로그아웃
-	logoutHandler := &handler.LogoutHandler{}
-	mux.Post("/logout", logoutHandler.ServeHTTP)
-
-	// jwt 유효성 검사
-	jwtVaildHandler := &handler.JwtValidHandler{
-		Jwt: jwt,
-	}
-	mux.Get("/jwt-validation", jwtVaildHandler.ServeHTTP)
-
-	// Begin :: 코드관리
-	codeHandler := &handler.HandlerCode{
-		Service: service.ServiceCode{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-
-	mux.Route("/code", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/", codeHandler.ListByPCode)          // code 조회
-		r.Get("/tree", codeHandler.ListCodeTree)     // codeTree 조회
-		r.Get("/check", codeHandler.DuplicateByCode) // code 조회
-		r.Post("/", codeHandler.Merge)               // 코드 추가 및 수정
-		r.Delete("/{idx}", codeHandler.Remove)       // 코드 삭제
-		r.Post("/sort", codeHandler.SortNoModify)    // 코드순서 수정
+	// 공개 라우팅
+	mux.Mount("/login", route.LoginRoute(jwt, safeDb, &r)) // 로그인
+	mux.Mount("/logout", route.LogoutRoute())              // 로그아웃
+	mux.Mount("/jwt-validation", route.JwtVaildRout(jwt))  // jwt 유효성 검사
+	// 인증 라우팅
+	mux.Group(func(router chi.Router) {
+		router.Use(handler.AuthMiddleware(jwt))                                // jwt 인증
+		router.Mount("/api", route.ApiRoute(apiCfg, safeDb, &r))               // api
+		router.Mount("/excel", route.ExcelRoute())                             // 엑셀
+		router.Mount("/project", route.ProjectRoute(safeDb, &r))               // 프로젝트
+		router.Mount("/organization", route.OrganiztionRoute(timesheetDb, &r)) // 조직도
+		router.Mount("/site", route.SiteRoute(safeDb, &r, apiCfg))             // 현장
+		router.Mount("/worker", route.WorkerRoute(safeDb, &r))                 // 근로자
+		router.Mount("/equip", route.EquipRoute(safeDb, &r))                   // 장비 (임시)
+		router.Mount("/device", route.DeviceRoute(safeDb, &r))                 // 근태인식기
+		router.Mount("/company", route.CompanyRoute(safeDb, timesheetDb, &r))  // 협력업체
+		router.Mount("/schedule", route.ScheduleRoute(safeDb, &r))             // 일정관리
+		router.Mount("/notice", route.NoticeRoute(safeDb, &r))                 // 공지사항
+		router.Mount("/code", route.CodeRoute(safeDb, &r))                     // 코드
 	})
-	// End :: 코드관리
 
-	// Begin::현장관리
-	siteHandler := &handler.HandlerSite{
-		Service: &service.ServiceSite{
-			SafeDB:            safeDb,
-			SafeTDB:           safeDb,
-			Store:             &r,
-			ProjectStore:      &r,
-			ProjectDailyStore: &r,
-			SitePosStore:      &r,
-			SiteDateStore:     &r,
-			ProjectService: &service.ServiceProject{
-				SafeDB:    safeDb,
-				Store:     &r,
-				UserStore: &r,
-			},
-			WhetherApiService: &service.ServiceWhether{
-				ApiKey: apiCfg,
-			},
-			AddressSearchAPIService: &service.ServiceAddressSearch{
-				ApiKey: apiCfg,
-			},
-		},
-		CodeService: &service.ServiceCode{
-			SafeDB: safeDb,
-			Store:  &r,
-		},
-		Jwt: jwt,
-	}
-	mux.Route("/site", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/", siteHandler.List)                // 현장관리 조회
-		r.Get("/nm", siteHandler.SiteNameList)      // 현장명 조회
-		r.Get("/stats", siteHandler.StatsList)      // 현장상태조회
-		r.Post("/", siteHandler.Add)                // 현장 생성
-		r.Put("/", siteHandler.Modify)              // 수정
-		r.Put("/non-use", siteHandler.ModifyNonUse) // 현장 사용안함
-	})
-	// End::현장관리
-
-	// Begin::지도좌표
-	roadAddressHandler := &handler.HandlerRoadAddress{
-		Service: &service.ServiceAddressSearch{
-			ApiKey: apiCfg,
-		},
-	}
-	mux.Route("/map", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/point", roadAddressHandler.AddressPoint)
-	})
-	// End::지도좌표
-
-	// Begin:: api 호출
-	// 기상청 초단기 실황
-	handlerWhetherSrt := &handler.HandlerWhetherSrtNcst{
-		Service: &service.ServiceWhether{
-			ApiKey: apiCfg,
-		},
-		SitePosService: &service.ServiceSitePos{
-			DB:    safeDb,
-			Store: &r,
-		},
-	}
-
-	// 기상청 기상특보통보문 조회
-	handlerWhetherWrn := &handler.HandlerWhetherWrnMsg{
-		Service: &service.ServiceWhether{
-			ApiKey: apiCfg,
-		},
-	}
-
-	// 공휴일 조회
-	restDatehandler := &handler.HandlerRestDate{
-		Service: &service.ServiceRestDate{
-			ApiKey: apiCfg,
-		},
-	}
-
-	mux.Route("/api", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/whether/srt", handlerWhetherSrt.ServeHTTP)
-		r.Get("/whether/wrn", handlerWhetherWrn.ServeHTTP)
-		r.Get("/rest-date", restDatehandler.ServeHTTP)
-	})
-	// End:: api 호출
-
-	// Begin::프로젝트
-	projectHandler := &handler.HandlerProject{
-		Service: &service.ServiceProject{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-	mux.Route("/project", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/", projectHandler.RegList)                        // 공사관리시스템 등록 프로젝트 전체 조회
-		r.Get("/worker-count", projectHandler.WorkerCountList)    // 프로젝트별 근로자 수 조회
-		r.Get("/enterprise", projectHandler.EnterpriseList)       // 프로젝트 전체 조회
-		r.Get("/job_name", projectHandler.JobNameList)            // 프로젝트 이름 조회
-		r.Get("/my-org/{uno}", projectHandler.MyOrgList)          // 본인이 속한 조직도의 프로젝트 조회
-		r.Get("/my-job_name/{uno}", projectHandler.MyJobNameList) // 본인이 속한 프로젝트 이름 목록
-		r.Get("/non-reg", projectHandler.NonRegList)              // 현장근태 사용되지 않은 프로젝트
-		r.Post("/", projectHandler.Add)                           // 추가
-		r.Put("/default", projectHandler.ModifyDefault)           // 현장 기본 프로젝트 변경
-		r.Put("/use", projectHandler.ModifyIsUse)                 // 현장 프로젝트 사용여부 변경
-		r.Delete("/{sno}/{jno}", projectHandler.Remove)           // 현장 프로젝트 삭제
-	})
-	// End::프로젝트 조회
-
-	// Begin::조직도
-	organizationHandler := &handler.HandlerOrganization{
-		Service: &service.ServiceOrganization{
-			SafeDB: timesheetDb,
-			Store:  &r,
-		},
-	}
-	mux.Route("/organization", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/{jno}", organizationHandler.ByProjectList) // 선택한 프로젝트의 조직도 조회
-	})
-	// End::조직도
-
-	// Begin::근태인식기
-	deviceHandler := &handler.DeviceHandler{
-		Service: &service.ServiceDevice{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-	mux.Route("/device", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/", deviceHandler.List)                            // 조회
-		r.Post("/", deviceHandler.Add)                            // 추가
-		r.Put("/", deviceHandler.Modify)                          // 수정
-		r.Delete("/{id}", deviceHandler.Remove)                   // 삭제
-		r.Get("/check-registered", deviceHandler.CheckRegistered) // 장치 등록 확인
-	})
-	// End::근태인식기
-
-	// Begin::근로자
-	workerHandler := handler.HandlerWorker{
-		Service: &service.ServiceWorker{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-	mux.Route("/worker", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/total", workerHandler.TotalList)                    // 전체근로자 조회
-		r.Get("/total/simple", workerHandler.AbsentList)            // 근로자 검색(현장근로자 추가시 사용)
-		r.Post("/total", workerHandler.Add)                         // 추가
-		r.Put("/total", workerHandler.Modify)                       // 수정
-		r.Get("/site-base", workerHandler.SiteBaseList)             // 현장근로자 조회
-		r.Post("/site-base", workerHandler.Merge)                   // 현장근로자 추가&수정
-		r.Post("/site-base/deadline", workerHandler.ModifyDeadline) // 현장근로자 마감처리
-		r.Post("/site-base/project", workerHandler.ModifyProject)   // 현장근로자 프로젝트 이동
-	})
-	// End::근로자
-
-	// Begin::협력업체
-	companyHandler := handler.HandlerCompany{
-		Service: &service.ServiceCompany{
-			SafeDB:      safeDb,
-			TimeSheetDB: timesheetDb,
-			Store:       &r,
-		},
-	}
-	mux.Route("/company", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/job-info", companyHandler.JobInfo)         // job 정보 조회
-		r.Get("/site-manager", companyHandler.SiteManager) // 현장소장 조회
-		r.Get("/safe-manager", companyHandler.SafeManager) // 안전관리자 조회
-		r.Get("/supervisor", companyHandler.Supervisor)    // 관리감독자 조회
-		r.Get("/work-info", companyHandler.WorkInfo)       // 공종 정보 조회
-		r.Get("/company-info", companyHandler.CompanyInfo) // 협력업체 정보
-	})
-	// End::협력업체
-
-	// Begin::공지사항
-	noticeHandler := &handler.NoticeHandler{
-		Service: &service.ServiceNotice{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-	mux.Route("/notice", func(router chi.Router) {
-		router.Use(handler.AuthMiddleware(jwt))
-		router.Get("/{uno}", noticeHandler.List)      // 조회
-		router.Post("/", noticeHandler.Add)           // 추가
-		router.Put("/", noticeHandler.Modify)         // 수정
-		router.Delete("/{idx}", noticeHandler.Remove) // 삭제
-	})
-	// End::공지사항
-
-	// Begin::장비
-	// 장비 핸들러
-	equipHandler := &handler.HandlerEquip{
-		Service: &service.ServiceEquip{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-	mux.Route("/equip", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/", equipHandler.List)   // 장비 조회 (임시)
-		r.Post("/", equipHandler.Merge) // 장비 입력 (임시)
-	})
-	// End::장비
-
-	// Begin::일정관리
-	// 휴무일
-	restScheduleHandler := &handler.HandlerRestSchedule{
-		Service: &service.ServiceSchedule{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-	// 작업내용
-	dailyJobHandler := &handler.HandlerProjectDaily{
-		Service: &service.ServiceProjectDaily{
-			SafeDB:  safeDb,
-			SafeTDB: safeDb,
-			Store:   &r,
-		},
-	}
-	mux.Route("/schedule", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Get("/rest", restScheduleHandler.RestList)            // 휴무일 조회
-		r.Post("/rest", restScheduleHandler.RestAdd)            // 휴무일 추가
-		r.Put("/rest", restScheduleHandler.RestModify)          // 휴무일 수정
-		r.Delete("/rest/{cno}", restScheduleHandler.RestRemove) // 휴무일 삭제
-		r.Get("/daily-job", dailyJobHandler.List)               // 작업내용 조회
-		r.Post("/daily-job", dailyJobHandler.Add)               // 작업내용 추가
-		r.Put("/daily-job", dailyJobHandler.Modify)             // 작업내용 수정
-		r.Delete("/daily-job/{cno}", dailyJobHandler.Remove)    // 작업내용 삭제
-	})
-	// End::일정관리
-
-	// Begin::엑셀
-	excelHandler := &handler.HandlerExcel{
-		Service: &service.ServiceExcel{},
-	}
-	mux.Route("/excel", func(r chi.Router) {
-		r.Use(handler.AuthMiddleware(jwt))
-		r.Post("/export/daily-deduction", excelHandler.ExportDailyDeduction) // 일별퇴직공제 export
-		r.Post("/import/deduction", excelHandler.ImportDeduction)            // 퇴직공제 import
-	})
-	// End::엑셀
-
-	// 라우팅:: end
-
-	handlerMux := c.Handler(mux)
-
-	return handlerMux, nil
+	return c.Handler(mux), nil
 }

--- a/csm-api/route/route_api.go
+++ b/csm-api/route/route_api.go
@@ -1,0 +1,53 @@
+package route
+
+import (
+	"csm-api/config"
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func ApiRoute(apiConfig *config.ApiConfig, safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	// 지도 좌표
+	roadAddressHandler := &handler.HandlerRoadAddress{
+		Service: &service.ServiceAddressSearch{
+			ApiKey: apiConfig,
+		},
+	}
+
+	// 기상청 초단기 실황
+	handlerWhetherSrt := &handler.HandlerWhetherSrtNcst{
+		Service: &service.ServiceWhether{
+			ApiKey: apiConfig,
+		},
+		SitePosService: &service.ServiceSitePos{
+			DB:    safeDB,
+			Store: r,
+		},
+	}
+
+	// 기상청 기상특보통보문 조회
+	handlerWhetherWrn := &handler.HandlerWhetherWrnMsg{
+		Service: &service.ServiceWhether{
+			ApiKey: apiConfig,
+		},
+	}
+
+	// 공휴일 조회
+	restDatehandler := &handler.HandlerRestDate{
+		Service: &service.ServiceRestDate{
+			ApiKey: apiConfig,
+		},
+	}
+
+	router.Get("/map/point", roadAddressHandler.AddressPoint) // 지도 좌표
+	router.Get("/whether/srt", handlerWhetherSrt.ServeHTTP)   // 기상청 초단기 실황
+	router.Get("/whether/wrn", handlerWhetherWrn.ServeHTTP)   // 기상청 기상특보통보문 조회
+	router.Get("/rest-date", restDatehandler.ServeHTTP)       // 공휴일 조회
+
+	return router
+}

--- a/csm-api/route/route_code.go
+++ b/csm-api/route/route_code.go
@@ -1,0 +1,30 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func CodeRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	codeHandler := &handler.HandlerCode{
+		Service: service.ServiceCode{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/", codeHandler.ListByPCode)          // code 조회
+	router.Get("/tree", codeHandler.ListCodeTree)     // codeTree 조회
+	router.Get("/check", codeHandler.DuplicateByCode) // code 조회
+	router.Post("/", codeHandler.Merge)               // 코드 추가 및 수정
+	router.Delete("/{idx}", codeHandler.Remove)       // 코드 삭제
+	router.Post("/sort", codeHandler.SortNoModify)    // 코드순서 수정
+
+	return router
+}

--- a/csm-api/route/route_company.go
+++ b/csm-api/route/route_company.go
@@ -1,0 +1,30 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func CompanyRoute(safeDB *sqlx.DB, timeSheetDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	companyHandler := handler.HandlerCompany{
+		Service: &service.ServiceCompany{
+			SafeDB:      safeDB,
+			TimeSheetDB: timeSheetDB,
+			Store:       r,
+		},
+	}
+
+	router.Get("/job-info", companyHandler.JobInfo)         // job 정보 조회
+	router.Get("/site-manager", companyHandler.SiteManager) // 현장소장 조회
+	router.Get("/safe-manager", companyHandler.SafeManager) // 안전관리자 조회
+	router.Get("/supervisor", companyHandler.Supervisor)    // 관리감독자 조회
+	router.Get("/work-info", companyHandler.WorkInfo)       // 공종 정보 조회
+	router.Get("/company-info", companyHandler.CompanyInfo) // 협력업체 정보
+
+	return router
+}

--- a/csm-api/route/route_device.go
+++ b/csm-api/route/route_device.go
@@ -1,0 +1,29 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func DeviceRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	deviceHandler := &handler.DeviceHandler{
+		Service: &service.ServiceDevice{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/", deviceHandler.List)                            // 조회
+	router.Post("/", deviceHandler.Add)                            // 추가
+	router.Put("/", deviceHandler.Modify)                          // 수정
+	router.Delete("/{id}", deviceHandler.Remove)                   // 삭제
+	router.Get("/check-registered", deviceHandler.CheckRegistered) // 장치 등록 확인
+
+	return router
+}

--- a/csm-api/route/route_equip.go
+++ b/csm-api/route/route_equip.go
@@ -1,0 +1,26 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func EquipRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	equipHandler := &handler.HandlerEquip{
+		Service: &service.ServiceEquip{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/", equipHandler.List)   // 장비 조회 (임시)
+	router.Post("/", equipHandler.Merge) // 장비 입력 (임시)
+
+	return router
+}

--- a/csm-api/route/route_excel.go
+++ b/csm-api/route/route_excel.go
@@ -1,0 +1,20 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"github.com/go-chi/chi/v5"
+)
+
+func ExcelRoute() chi.Router {
+	router := chi.NewRouter()
+
+	excelHandler := &handler.HandlerExcel{
+		Service: &service.ServiceExcel{},
+	}
+
+	router.Post("/export/daily-deduction", excelHandler.ExportDailyDeduction) // 일별퇴직공제 export
+	router.Post("/import/deduction", excelHandler.ImportDeduction)            // 퇴직공제 import
+
+	return router
+}

--- a/csm-api/route/route_jwt_vaild.go
+++ b/csm-api/route/route_jwt_vaild.go
@@ -1,0 +1,18 @@
+package route
+
+import (
+	"csm-api/auth"
+	"csm-api/handler"
+	"github.com/go-chi/chi/v5"
+)
+
+func JwtVaildRout(jwt *auth.JWTUtils) chi.Router {
+	router := chi.NewRouter()
+
+	jwtVaildHandler := &handler.JwtValidHandler{
+		Jwt: jwt,
+	}
+	router.Get("/", jwtVaildHandler.ServeHTTP)
+
+	return router
+}

--- a/csm-api/route/route_login.go
+++ b/csm-api/route/route_login.go
@@ -1,0 +1,35 @@
+package route
+
+import (
+	"csm-api/auth"
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func LoginRoute(jwt *auth.JWTUtils, safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	loginHandler := &handler.LoginHandler{
+		Service: &service.UserValid{
+			DB:    safeDB,
+			Store: r,
+		},
+		Jwt: jwt,
+	}
+
+	router.Post("/", loginHandler.ServeHTTP)
+
+	return router
+}
+
+func LogoutRoute() chi.Router {
+	router := chi.NewRouter()
+
+	logoutHandler := &handler.LogoutHandler{}
+	router.Post("/", logoutHandler.ServeHTTP)
+
+	return router
+}

--- a/csm-api/route/route_notice.go
+++ b/csm-api/route/route_notice.go
@@ -1,0 +1,28 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func NoticeRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	noticeHandler := &handler.NoticeHandler{
+		Service: &service.ServiceNotice{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/{uno}", noticeHandler.List)      // 조회
+	router.Post("/", noticeHandler.Add)           // 추가
+	router.Put("/", noticeHandler.Modify)         // 수정
+	router.Delete("/{idx}", noticeHandler.Remove) // 삭제
+
+	return router
+}

--- a/csm-api/route/route_organization.go
+++ b/csm-api/route/route_organization.go
@@ -1,0 +1,24 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func OrganiztionRoute(timeSheetDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	organizationHandler := &handler.HandlerOrganization{
+		Service: &service.ServiceOrganization{
+			TimeSheetDB: timeSheetDB,
+			Store:       r,
+		},
+	}
+
+	router.Get("/{jno}", organizationHandler.ByProjectList) // 선택한 프로젝트의 조직도 조회
+
+	return router
+}

--- a/csm-api/route/route_project.go
+++ b/csm-api/route/route_project.go
@@ -1,0 +1,35 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func ProjectRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	projectHandler := &handler.HandlerProject{
+		Service: &service.ServiceProject{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/", projectHandler.RegList)                        // 공사관리시스템 등록 프로젝트 전체 조회
+	router.Get("/worker-count", projectHandler.WorkerCountList)    // 프로젝트별 근로자 수 조회
+	router.Get("/enterprise", projectHandler.EnterpriseList)       // 프로젝트 전체 조회
+	router.Get("/job_name", projectHandler.JobNameList)            // 프로젝트 이름 조회
+	router.Get("/my-org/{uno}", projectHandler.MyOrgList)          // 본인이 속한 조직도의 프로젝트 조회
+	router.Get("/my-job_name/{uno}", projectHandler.MyJobNameList) // 본인이 속한 프로젝트 이름 목록
+	router.Get("/non-reg", projectHandler.NonRegList)              // 현장근태 사용되지 않은 프로젝트
+	router.Post("/", projectHandler.Add)                           // 추가
+	router.Put("/default", projectHandler.ModifyDefault)           // 현장 기본 프로젝트 변경
+	router.Put("/use", projectHandler.ModifyIsUse)                 // 현장 프로젝트 사용여부 변경
+	router.Delete("/{sno}/{jno}", projectHandler.Remove)           // 현장 프로젝트 삭제
+
+	return router
+}

--- a/csm-api/route/route_schedule.go
+++ b/csm-api/route/route_schedule.go
@@ -1,0 +1,41 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func ScheduleRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	// 휴무일
+	restScheduleHandler := &handler.HandlerRestSchedule{
+		Service: &service.ServiceSchedule{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+	// 작업내용
+	dailyJobHandler := &handler.HandlerProjectDaily{
+		Service: &service.ServiceProjectDaily{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/rest", restScheduleHandler.RestList)            // 휴무일 조회
+	router.Post("/rest", restScheduleHandler.RestAdd)            // 휴무일 추가
+	router.Put("/rest", restScheduleHandler.RestModify)          // 휴무일 수정
+	router.Delete("/rest/{cno}", restScheduleHandler.RestRemove) // 휴무일 삭제
+	router.Get("/daily-job", dailyJobHandler.List)               // 작업내용 조회
+	router.Post("/daily-job", dailyJobHandler.Add)               // 작업내용 추가
+	router.Put("/daily-job", dailyJobHandler.Modify)             // 작업내용 수정
+	router.Delete("/daily-job/{cno}", dailyJobHandler.Remove)    // 작업내용 삭제
+
+	return router
+}

--- a/csm-api/route/route_site.go
+++ b/csm-api/route/route_site.go
@@ -1,0 +1,50 @@
+package route
+
+import (
+	"csm-api/config"
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func SiteRoute(safeDB *sqlx.DB, r *store.Repository, apiConfig *config.ApiConfig) chi.Router {
+	router := chi.NewRouter()
+
+	siteHandler := &handler.HandlerSite{
+		Service: &service.ServiceSite{
+			SafeDB:            safeDB,
+			SafeTDB:           safeDB,
+			Store:             r,
+			ProjectStore:      r,
+			ProjectDailyStore: r,
+			SitePosStore:      r,
+			SiteDateStore:     r,
+			ProjectService: &service.ServiceProject{
+				SafeDB:    safeDB,
+				Store:     r,
+				UserStore: r,
+			},
+			WhetherApiService: &service.ServiceWhether{
+				ApiKey: apiConfig,
+			},
+			AddressSearchAPIService: &service.ServiceAddressSearch{
+				ApiKey: apiConfig,
+			},
+		},
+		CodeService: &service.ServiceCode{
+			SafeDB: safeDB,
+			Store:  r,
+		},
+	}
+
+	router.Get("/", siteHandler.List)                // 현장관리 조회
+	router.Get("/nm", siteHandler.SiteNameList)      // 현장명 조회
+	router.Get("/stats", siteHandler.StatsList)      // 현장상태조회
+	router.Post("/", siteHandler.Add)                // 현장 생성
+	router.Put("/", siteHandler.Modify)              // 수정
+	router.Put("/non-use", siteHandler.ModifyNonUse) // 현장 사용안함
+
+	return router
+}

--- a/csm-api/route/route_worker.go
+++ b/csm-api/route/route_worker.go
@@ -1,0 +1,32 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func WorkerRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	workerHandler := handler.HandlerWorker{
+		Service: &service.ServiceWorker{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/total", workerHandler.TotalList)                    // 전체근로자 조회
+	router.Get("/total/simple", workerHandler.AbsentList)            // 근로자 검색(현장근로자 추가시 사용)
+	router.Post("/total", workerHandler.Add)                         // 추가
+	router.Put("/total", workerHandler.Modify)                       // 수정
+	router.Get("/site-base", workerHandler.SiteBaseList)             // 현장근로자 조회
+	router.Post("/site-base", workerHandler.Merge)                   // 현장근로자 추가&수정
+	router.Post("/site-base/deadline", workerHandler.ModifyDeadline) // 현장근로자 마감처리
+	router.Post("/site-base/project", workerHandler.ModifyProject)   // 현장근로자 프로젝트 이동
+
+	return router
+}

--- a/csm-api/service/service_organization.go
+++ b/csm-api/service/service_organization.go
@@ -9,8 +9,8 @@ import (
 )
 
 type ServiceOrganization struct {
-	SafeDB store.Queryer
-	Store  store.OrganizationStore
+	TimeSheetDB store.Queryer
+	Store       store.OrganizationStore
 }
 
 // func: 조직도 조회: 고객사
@@ -26,7 +26,7 @@ func (s *ServiceOrganization) GetOrganizationClientList(ctx context.Context, jno
 	}
 
 	clientSql := &entity.OrganizationSqls{}
-	clientSql, err := s.Store.GetOrganizationClientList(ctx, s.SafeDB, jnoSql)
+	clientSql, err := s.Store.GetOrganizationClientList(ctx, s.TimeSheetDB, jnoSql)
 	if err != nil {
 		//TODO: 에러 아카이브
 		return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/GetOrganizationClientList: %w", err)
@@ -77,7 +77,7 @@ func (s *ServiceOrganization) GetOrganizationHtencList(ctx context.Context, jno 
 		jnoSql = sql.NullInt64{Valid: false}
 	}
 
-	funcNameSqls, err := s.Store.GetFuncNameList(ctx, s.SafeDB)
+	funcNameSqls, err := s.Store.GetFuncNameList(ctx, s.TimeSheetDB)
 	if err != nil {
 		//TODO: 에러 아카이브
 		return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/GetFuncNameList: %w", err)
@@ -100,7 +100,7 @@ func (s *ServiceOrganization) GetOrganizationHtencList(ctx context.Context, jno 
 
 		organization := entity.OrganizationPartition{}
 		hitechSql := &entity.OrganizationSqls{}
-		hitechSql, err := s.Store.GetOrganizationHtencList(ctx, s.SafeDB, jnoSql, funcNoSql)
+		hitechSql, err := s.Store.GetOrganizationHtencList(ctx, s.TimeSheetDB, jnoSql, funcNoSql)
 		if err != nil {
 			//TODO: 에러 아카이브
 			return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/GetOrganizationHtencList: %w", err)


### PR DESCRIPTION
기존에 mux.go에서 chi패키지를 이용하여 http method에 따른 여러 요청을 라우팅 할 수 있음 newMux()함수를 구현하였는데 라우트만을 위한 코드가 아닌 핸들러/서비스 생성 코드가 모두 몰려있다 보니 라우팅의 책임과 비즈니스 로직 생성 책임이 분리되지 않아 `단일 책임 원칙(SRP)`에 부합되지 않았음 go의 설계철학과 유지보수성과 확장성을 높이기 위하여 route 파일을 새롭게 생성하여 route파일에서 핸들러/서비스의 의존성을 코드에서 명시적으로 전달하여 생성할 수 있도록 분리하여 라우팅은 Mux에서, 기능은 각 Route에서 할 수 있도록 리팩토링 함