### PR TITLE
일일 근로자 비교 및 그 외

### DIFF
--- a/csm-api/ctxutil/transaction.go
+++ b/csm-api/ctxutil/transaction.go
@@ -1,0 +1,44 @@
+package ctxutil
+
+import (
+	"context"
+	"fmt"
+	"github.com/jmoiron/sqlx"
+)
+
+type ctxTxKey struct{}
+
+var txKey = ctxTxKey{}
+
+func WithTx(ctx context.Context, db *sqlx.DB) (context.Context, error) {
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	ctx = context.WithValue(ctx, txKey, tx)
+	return ctx, nil
+}
+
+func GetTx(ctx context.Context) (*sqlx.Tx, bool) {
+	tx, ok := ctx.Value(txKey).(*sqlx.Tx)
+	return tx, ok
+}
+
+func DeferTx(ctx context.Context, handler string, errRef *error) func() {
+	tx, ok := GetTx(ctx)
+	if !ok || tx == nil {
+		return func() {} // no-op
+	}
+
+	return func() {
+		if *errRef != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				*errRef = fmt.Errorf("%s: failed to rollback transaction: %w", handler, rollbackErr)
+			}
+		} else {
+			if commitErr := tx.Commit(); commitErr != nil {
+				*errRef = fmt.Errorf("%s: failed to commit transaction: %w", handler, commitErr)
+			}
+		}
+	}
+}

--- a/csm-api/entity/compare.go
+++ b/csm-api/entity/compare.go
@@ -3,17 +3,20 @@ package entity
 import "github.com/guregu/null"
 
 type Compare struct {
-	Jno              null.Int    `json:"jno"`
-	UserId           null.String `json:"user_id"`
-	UserNm           null.String `json:"user_nm"`
-	Department       null.String `json:"department"`
-	DiscName         null.String `json:"disc_name"`
-	IsTbm            null.String `json:"is_tbm"`
-	RecordDate       null.Time   `json:"record_date"`
-	WorkerInTime     null.Time   `json:"worker_in_time"`
-	WorkerOutTime    null.Time   `json:"worker_out_time"`
-	CompareState     null.String `json:"compare_state"`
-	IsDeadline       null.String `json:"is_deadline"`
-	DeductionInTime  null.Time   `json:"deduction_in_time"`
-	DeductionOutTime null.Time   `json:"deduction_out_time"`
+	Sno              null.Int    `json:"sno" db:"SNO"`
+	Jno              null.Int    `json:"jno" db:"JNO"`
+	UserId           null.String `json:"user_id" db:"USER_ID"`
+	UserNm           null.String `json:"user_nm" db:"USER_NM"`
+	Department       null.String `json:"department" db:"DEPARTMENT"`
+	DiscName         null.String `json:"disc_name" db:"DISC_NAME"`
+	Gender           null.String `json:"gender" db:"GENDER"`
+	IsTbm            null.String `json:"is_tbm" db:"IS_TBM"`
+	RecordDate       null.Time   `json:"record_date" db:"RECORD_DATE"`
+	WorkerInTime     null.Time   `json:"worker_in_time" db:"WORKER_IN_TIME"`
+	WorkerOutTime    null.Time   `json:"worker_out_time" db:"WORKER_OUT_TIME"`
+	CompareState     null.String `json:"compare_state" db:"COMPARE_STATE"`
+	IsDeadline       null.String `json:"is_deadline" db:"IS_DEADLINE"`
+	DeductionInTime  null.Time   `json:"deduction_in_time" db:"DEDUCTION_IN_TIME"`
+	DeductionOutTime null.Time   `json:"deduction_out_time" db:"DEDUCTION_OUT_TIME"`
+	DeductionBirth   null.String `json:"deduction_birth" db:"DEDUCTION_BIRTH"`
 }

--- a/csm-api/entity/deduction.go
+++ b/csm-api/entity/deduction.go
@@ -21,6 +21,7 @@ type Deduction struct {
 }
 
 type DeductionKey struct {
+	Sno        int64
 	Jno        int64
 	UserNm     string
 	Department string
@@ -28,7 +29,9 @@ type DeductionKey struct {
 }
 
 type DeductionRegKey struct {
+	Sno        int64
 	Jno        int64
+	Phone      string
 	RegNo      string // ' ', '-' 제거 주민번호
 	RecordDate time.Time
 }

--- a/csm-api/entity/tbm.go
+++ b/csm-api/entity/tbm.go
@@ -17,6 +17,7 @@ type Tbm struct {
 }
 
 type TbmKey struct {
+	Sno        int64
 	Jno        int64
 	UserNm     string
 	Department string

--- a/csm-api/handler/handler_project.go
+++ b/csm-api/handler/handler_project.go
@@ -265,6 +265,22 @@ func (h *HandlerProject) MyOrgList(w http.ResponseWriter, r *http.Request) {
 	SuccessValuesResponse(ctx, w, values)
 }
 
+func (h *HandlerProject) ProjectBySite(w http.ResponseWriter, r *http.Request) {
+	snoString := r.URL.Query().Get("sno")
+	if snoString == "" {
+		BadRequestResponse(r.Context(), w)
+		return
+	}
+
+	sno, _ := strconv.ParseInt(snoString, 10, 64)
+	list, err := h.Service.GetProjectBySite(r.Context(), sno)
+	if err != nil {
+		FailResponse(r.Context(), w, err)
+		return
+	}
+	SuccessValuesResponse(r.Context(), w, list)
+}
+
 // func: 본인이 속한 프로젝트 이름 목록
 // @param
 // -

--- a/csm-api/route/route_compare.go
+++ b/csm-api/route/route_compare.go
@@ -20,7 +20,7 @@ func CompareRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 	}
 
 	router.Get("/", compareHandler.List)         // 일일근로자비교 리스트
-	router.Put("/", compareHandler.CompareState) // 일일근로자비교 반영/취소
+	router.Put("/", compareHandler.CompareState) // 일일근로자비교 반영
 
 	return router
 }

--- a/csm-api/route/route_excel.go
+++ b/csm-api/route/route_excel.go
@@ -22,6 +22,7 @@ func ExcelRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 			TDB:   safeDB,
 			Store: r,
 		},
+		DB: safeDB,
 	}
 
 	router.Post("/import", excelHandler.ImportExcel) // excel import

--- a/csm-api/route/route_project.go
+++ b/csm-api/route/route_project.go
@@ -26,6 +26,7 @@ func ProjectRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 	router.Get("/my-org/{uno}", projectHandler.MyOrgList)          // 본인이 속한 조직도의 프로젝트 조회
 	router.Get("/my-job_name/{uno}", projectHandler.MyJobNameList) // 본인이 속한 프로젝트 이름 목록
 	router.Get("/non-reg", projectHandler.NonRegList)              // 현장근태 사용되지 않은 프로젝트
+	router.Get("/project-by-site", projectHandler.ProjectBySite)   // 현장별 프로젝트 조회
 	router.Post("/", projectHandler.Add)                           // 추가
 	router.Put("/default", projectHandler.ModifyDefault)           // 현장 기본 프로젝트 변경
 	router.Put("/use", projectHandler.ModifyIsUse)                 // 현장 프로젝트 사용여부 변경

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -45,6 +45,7 @@ type ProjectService interface {
 	GetProjectNmUnoList(ctx context.Context, uno int64, role string) (*entity.ProjectInfos, error)
 	GetNonUsedProjectList(ctx context.Context, page entity.Page, search entity.NonUsedProject, retry string) (*entity.NonUsedProjects, error)
 	GetNonUsedProjectCount(ctx context.Context, search entity.NonUsedProject, retry string) (int, error)
+	GetProjectBySite(ctx context.Context, sno int64) (entity.ProjectInfos, error)
 	AddProject(ctx context.Context, project entity.ReqProject) error
 	ModifyDefaultProject(ctx context.Context, project entity.ReqProject) error
 	ModifyUseProject(ctx context.Context, project entity.ReqProject) error
@@ -156,6 +157,6 @@ type UploadFileService interface {
 }
 
 type CompareService interface {
-	GetCompareList(ctx context.Context, jno int64, startDate null.Time, retry string, order string) ([]entity.Compare, error)
-	ModifyWorkerCompareState(ctx context.Context, workers entity.WorkerDailys) error
+	GetCompareList(ctx context.Context, compare entity.Compare, retry string, order string) ([]entity.Compare, error)
+	ModifyWorkerCompareApply(ctx context.Context, workers entity.WorkerDailys) error
 }

--- a/csm-api/service/service_excel.go
+++ b/csm-api/service/service_excel.go
@@ -2,11 +2,13 @@ package service
 
 import (
 	"context"
+	"csm-api/ctxutil"
 	"csm-api/entity"
 	"csm-api/store"
 	"csm-api/utils"
 	"fmt"
 	"github.com/xuri/excelize/v2"
+	"strings"
 )
 
 type ServiceExcel struct {
@@ -20,6 +22,11 @@ func (s *ServiceExcel) ImportTbm(ctx context.Context, path string, tbm entity.Tb
 	f, err := excelize.OpenFile(path)
 	if err != nil {
 		return fmt.Errorf("ImportTbm.failed to open Excel file: %w", err)
+	}
+
+	order, err := s.Store.GetTbmOrder(ctx, s.SafeDB, tbm)
+	if err != nil {
+		return fmt.Errorf("ImportTbm.failed to GetTbm Order: %w", err)
 	}
 
 	var tbmList []entity.Tbm
@@ -47,10 +54,12 @@ func (s *ServiceExcel) ImportTbm(ctx context.Context, path string, tbm entity.Tb
 
 				if name != "" && sign != "" {
 					newTbm := entity.Tbm{
+						Sno:        tbm.Sno,
 						Jno:        tbm.Jno,
 						Department: tbm.Department,
 						DiscName:   tbm.DiscName,
 						TbmDate:    tbm.TbmDate,
+						TbmOrder:   utils.ParseNullInt(order),
 						UserNm:     utils.ParseNullString(name),
 						Base: entity.Base{
 							RegUser: tbm.RegUser,
@@ -63,26 +72,23 @@ func (s *ServiceExcel) ImportTbm(ctx context.Context, path string, tbm entity.Tb
 		}
 	}
 
-	tx, err := s.SafeTDB.BeginTx(ctx, nil)
-	if err != nil {
-		err = fmt.Errorf("ImportTbm.failed to begin transaction: %w", err)
-	}
-
-	defer func() {
+	tx, ok := ctxutil.GetTx(ctx)
+	if !ok || tx == nil {
+		tx, err = s.SafeTDB.BeginTxx(ctx, nil)
 		if err != nil {
-			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				err = fmt.Errorf("ImportTbm.failed to rollback transaction: %w", rollbackErr)
-			}
-		} else {
-			if commitErr := tx.Commit(); commitErr != nil {
-				err = fmt.Errorf("ImportTbm.failed to commit transaction: %w", commitErr)
-			}
+			return fmt.Errorf("serviceUploadFile.AddUploadFile: %w", err)
 		}
-	}()
-
-	// 기존 db 삭제
-	if err = s.Store.ModifyTbmExcel(ctx, tx, tbm); err != nil {
-		return fmt.Errorf("ImportTbm.failed to modify tbm: %w", err)
+		defer func() {
+			if err != nil {
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					err = fmt.Errorf("ImportTbm.failed to rollback transaction: %w", rollbackErr)
+				}
+			} else {
+				if commitErr := tx.Commit(); commitErr != nil {
+					err = fmt.Errorf("ImportTbm.failed to commit transaction: %w", commitErr)
+				}
+			}
+		}()
 	}
 
 	// db 저장
@@ -94,6 +100,113 @@ func (s *ServiceExcel) ImportTbm(ctx context.Context, path string, tbm entity.Tb
 }
 
 // 퇴직공제 excel import
-func (s *ServiceExcel) ImportDeduction(ctx context.Context, path string, deduction entity.Deduction) error {
-	return nil
+func (s *ServiceExcel) ImportDeduction(ctx context.Context, path string, deduction entity.Deduction) (err error) {
+	f, err := excelize.OpenFile(path)
+	if err != nil {
+		return fmt.Errorf("ImportDeduction: failed to open Excel file: %w", err)
+	}
+
+	order, err := s.Store.GetDeductionOrder(ctx, s.SafeDB, deduction)
+	if err != nil {
+		return fmt.Errorf("ImportDeduction: failed to GetDeductionOrder: %w", err)
+	}
+
+	siteNm, err := s.Store.GetDeductionSiteNameBySno(ctx, s.SafeDB, deduction.Sno.Int64)
+	if err != nil {
+		return fmt.Errorf("ImportDeduction: failed to GetDeductionSiteNameBySno: %w", err)
+	}
+
+	sheetName := f.GetSheetName(0)
+
+	var deductionList []entity.Deduction
+
+	// 3번째 행부터 (1-based index, 엑셀은 B3부터 시작)
+	for rowIdx := 3; ; rowIdx++ {
+		// B열(근무날짜)
+		cellAddr := fmt.Sprintf("B%d", rowIdx)
+		dateStr, err := f.GetCellValue(sheetName, cellAddr)
+		if err != nil || strings.TrimSpace(dateStr) == "" {
+			break
+		}
+		if dateStr == "" || utils.ConvertMMDDYYToYYMMDD(dateStr) != deduction.RecordDate.Time.Format("06-01-02") {
+			continue
+		}
+
+		// C열(현장명)
+		siteName, _ := f.GetCellValue(sheetName, fmt.Sprintf("C%d", rowIdx))
+		if utils.NormalizeForEqual(siteName) != utils.NormalizeForEqual(siteNm) {
+			continue
+		}
+
+		// G열(이름)
+		userNm := mustGet(f, sheetName, fmt.Sprintf("G%d", rowIdx))
+		// F열(회사명)
+		department := mustGet(f, sheetName, fmt.Sprintf("F%d", rowIdx))
+		// I열(성별)
+		gender := mustGet(f, sheetName, fmt.Sprintf("N%d", rowIdx))
+		// H열(생년월일)
+		regNo := mustGet(f, sheetName, fmt.Sprintf("H%d", rowIdx))
+		// I열(전화번호)
+		phone := mustGet(f, sheetName, fmt.Sprintf("I%d", rowIdx))
+		normalizedPhone := strings.ReplaceAll(strings.ReplaceAll(phone, "-", ""), " ", "")
+		if len(normalizedPhone) == 10 && strings.HasPrefix(normalizedPhone, "1") {
+			normalizedPhone = "0" + normalizedPhone
+		}
+		// O열(출근시간)
+		inTime := mustGet(f, sheetName, fmt.Sprintf("O%d", rowIdx))
+		// P열(퇴근시간)
+		outTime := mustGet(f, sheetName, fmt.Sprintf("P%d", rowIdx))
+
+		newDeduction := entity.Deduction{
+			Sno:          deduction.Sno,
+			UserNm:       utils.ParseNullString(userNm),
+			Department:   utils.ParseNullString(department),
+			Gender:       utils.ParseNullString(gender),
+			RegNo:        utils.ParseNullString(utils.ConvertMMDDYYToYYMMDD(regNo)),
+			Phone:        utils.ParseNullString(normalizedPhone),
+			InRecogTime:  utils.ParseNullDateTime(deduction.RecordDate.Time.Format("2006-01-02"), inTime),
+			OutRecogTime: utils.ParseNullDateTime(deduction.RecordDate.Time.Format("2006-01-02"), outTime),
+			RecordDate:   deduction.RecordDate,
+			DeductOrder:  utils.ParseNullString(order),
+			Base: entity.Base{
+				RegUser: deduction.RegUser,
+				RegUno:  deduction.RegUno,
+			},
+		}
+
+		if newDeduction.UserNm.Valid && newDeduction.Department.Valid && newDeduction.Gender.Valid && newDeduction.Phone.Valid {
+			deductionList = append(deductionList, newDeduction)
+		}
+	}
+
+	tx, ok := ctxutil.GetTx(ctx)
+	if !ok || tx == nil {
+		tx, err := s.SafeTDB.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("ImportDeduction: failed to begin transaction: %w", err)
+		}
+
+		defer func() {
+			if err != nil {
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					err = fmt.Errorf("ImportDeduction: failed to rollback transaction: %w", rollbackErr)
+				}
+			} else {
+				if commitErr := tx.Commit(); commitErr != nil {
+					err = fmt.Errorf("ImportDeduction: failed to commit transaction: %w", commitErr)
+				}
+			}
+		}()
+	}
+
+	if err = s.Store.AddDeductionExcel(ctx, tx, deductionList); err != nil {
+		return fmt.Errorf("ImportDeduction: failed to add deduction sheet: %w", err)
+	}
+
+	return
+}
+
+func mustGet(f *excelize.File, sheet, cell string) string {
+	val, _ := f.GetCellValue(sheet, cell)
+	return strings.TrimSpace(val)
 }

--- a/csm-api/service/service_project.go
+++ b/csm-api/service/service_project.go
@@ -301,6 +301,15 @@ func (s *ServiceProject) GetNonUsedProjectCount(ctx context.Context, search enti
 	return count, nil
 }
 
+// 현장별 프로젝트 조회
+func (s *ServiceProject) GetProjectBySite(ctx context.Context, sno int64) (entity.ProjectInfos, error) {
+	projectInfos, err := s.Store.GetProjectBySite(ctx, s.SafeDB, sno)
+	if err != nil {
+		return entity.ProjectInfos{}, fmt.Errorf("service_project/GetProjectBySite error: %w", err)
+	}
+	return projectInfos, nil
+}
+
 // func: 현장 프로젝트 추가
 // @param
 // -

--- a/csm-api/store/repository.go
+++ b/csm-api/store/repository.go
@@ -52,6 +52,7 @@ type Repository struct {
 
 type Beginner interface {
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+	BeginTxx(ctx context.Context, opts *sql.TxOptions) (*sqlx.Tx, error)
 }
 
 type Preparer interface {

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -49,6 +49,7 @@ type ProjectStore interface {
 	GetProjectNmUnoList(ctx context.Context, db Queryer, uno sql.NullInt64, role int) (*entity.ProjectInfos, error)
 	GetNonUsedProjectList(ctx context.Context, db Queryer, page entity.PageSql, search entity.NonUsedProject, retry string) (*entity.NonUsedProjects, error)
 	GetNonUsedProjectCount(ctx context.Context, db Queryer, search entity.NonUsedProject, retry string) (int, error)
+	GetProjectBySite(ctx context.Context, db Queryer, sno int64) (entity.ProjectInfos, error)
 	AddProject(ctx context.Context, tx Execer, project entity.ReqProject) error
 	ModifyDefaultProject(ctx context.Context, tx Execer, project entity.ReqProject) error
 	ModifyUseProject(ctx context.Context, tx Execer, project entity.ReqProject) error
@@ -151,14 +152,20 @@ type UploadFileStore interface {
 }
 
 type CompareStore interface {
-	GetDailyWorkerList(ctx context.Context, db Queryer, jno int64, startDate null.Time, retry string, order string) (entity.WorkerDailys, error)
-	GetTbmList(ctx context.Context, db Queryer, jno int64, startDate null.Time, retry string, order string) ([]entity.Tbm, error)
-	GetDeductionList(ctx context.Context, db Queryer, jno int64, startDate null.Time, retry string, order string) ([]entity.Deduction, error)
-	ModifyWorkerCompareState(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	GetDailyWorkerList(ctx context.Context, db Queryer, compare entity.Compare, retry string, order string) (entity.WorkerDailys, error)
+	GetTbmList(ctx context.Context, db Queryer, compare entity.Compare, retry string, order string) ([]entity.Tbm, error)
+	GetDeductionList(ctx context.Context, db Queryer, compare entity.Compare, retry string, order string) ([]entity.Deduction, error)
+	ModifyWorkerCompareApply(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	ModifyDailyWorkerCompareApply(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	ModifyTbmCompareApply(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	ModifyDeductionCompareApply(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	AddCompareLog(ctx context.Context, tx Execer, logs entity.WorkerDailys) error
 }
 
 type ExcelStore interface {
+	GetTbmOrder(ctx context.Context, db Queryer, tbm entity.Tbm) (string, error)
 	AddTbmExcel(ctx context.Context, tx Execer, tbm []entity.Tbm) error
-	ModifyTbmExcel(ctx context.Context, tx Execer, tbm entity.Tbm) error
+	GetDeductionSiteNameBySno(ctx context.Context, db Queryer, sno int64) (string, error)
+	GetDeductionOrder(ctx context.Context, db Queryer, tbm entity.Deduction) (string, error)
+	AddDeductionExcel(ctx context.Context, tx Execer, tbm []entity.Deduction) error
 }

--- a/csm-api/store/store_excel.go
+++ b/csm-api/store/store_excel.go
@@ -4,43 +4,107 @@ import (
 	"context"
 	"csm-api/entity"
 	"csm-api/utils"
+	"database/sql"
+	"errors"
 	"fmt"
+	"strconv"
 )
+
+// TBM 엑셀 차수 조회
+func (r *Repository) GetTbmOrder(ctx context.Context, db Queryer, tbm entity.Tbm) (string, error) {
+	var order sql.NullInt64
+
+	query := `
+		SELECT 
+			MAX(TBM_ORDER) 
+		FROM IRIS_TBM_SET
+		WHERE SNO = :1
+		AND DEPARTMENT = :2
+		AND TRUNC(TBM_DATE) = TRUNC(:3)`
+
+	if err := db.GetContext(ctx, &order, query, tbm.Sno, tbm.Department, tbm.TbmDate); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "0", nil
+		}
+		return "0", fmt.Errorf("GetTbmOrder: %w", err)
+	}
+
+	if !order.Valid {
+		return "0", nil
+	}
+
+	return strconv.FormatInt(order.Int64+1, 10), nil
+}
 
 // TBM 엑셀 정보 저장
 func (r *Repository) AddTbmExcel(ctx context.Context, tx Execer, tbms []entity.Tbm) error {
 	agent := utils.GetAgent()
 
 	query := `
-		INSERT INTO IRIS_TBM_SET(JNO, DEPARTMENT, DISC_NAME, USER_NM, TBM_DATE, REG_DATE, REG_USER, REG_UNO, REG_AGENT)
-		VALUES(:1, :2, :3, :4, :5, SYSDATE, :7, :8, :9)`
+		INSERT INTO IRIS_TBM_SET(SNO, DEPARTMENT, DISC_NAME, USER_NM, TBM_DATE, TBM_ORDER, REG_DATE, REG_USER, REG_UNO, REG_AGENT)
+		VALUES(:1, :2, :3, :4, :5, :6, SYSDATE, :7, :8, :9)`
 
 	for _, tbm := range tbms {
-		if _, err := tx.ExecContext(ctx, query, tbm.Jno, tbm.Department, tbm.DiscName, tbm.UserNm, tbm.TbmDate, tbm.RegUser, tbm.RegUno, agent); err != nil {
+		if _, err := tx.ExecContext(ctx, query, tbm.Sno, tbm.Department, tbm.DiscName, tbm.UserNm, tbm.TbmDate, tbm.TbmOrder, tbm.RegUser, tbm.RegUno, agent); err != nil {
 			return fmt.Errorf("AddTbmExcel: %w", err)
 		}
 	}
 	return nil
 }
 
-// TBM 엑셀 정보 사용 안함
-func (r *Repository) ModifyTbmExcel(ctx context.Context, tx Execer, tbm entity.Tbm) error {
+// 퇴직공제 현장명 조회
+func (r *Repository) GetDeductionSiteNameBySno(ctx context.Context, db Queryer, sno int64) (string, error) {
+	var name sql.NullString
+
+	query := `SELECT SITE_NM FROM IRIS_SITE_SET WHERE SNO = :1`
+
+	if err := db.GetContext(ctx, &name, query, sno); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("GetDeductionSiteNameBySno: %w", err)
+	}
+	if !name.Valid {
+		return "", nil
+	}
+	return name.String, nil
+}
+
+// 퇴직공제 차수 조회
+func (r *Repository) GetDeductionOrder(ctx context.Context, db Queryer, tbm entity.Deduction) (string, error) {
+	var order sql.NullInt64
+
+	query := `
+		SELECT 
+			MAX(DEDUCT_ORDER) 
+		FROM IRIS_DEDUCTION_SET
+		WHERE SNO = :1
+		AND TRUNC(RECORD_DATE) = TRUNC(:2)`
+
+	if err := db.GetContext(ctx, &order, query, tbm.Sno, tbm.RecordDate); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "0", nil
+		}
+		return "0", fmt.Errorf("GetDeductionOrder: %w", err)
+	}
+	if !order.Valid {
+		return "0", nil
+	}
+	return strconv.FormatInt(order.Int64+1, 10), nil
+}
+
+// 퇴직공제 엑셀 정보 저장
+func (r *Repository) AddDeductionExcel(ctx context.Context, tx Execer, tbms []entity.Deduction) error {
 	agent := utils.GetAgent()
 
 	query := `
-		UPDATE IRIS_TBM_SET
-		SET
-		    IS_USE = 'N',
-			MOD_DATE = SYSDATE,
-			MOD_USER = :1,
-			MOD_UNO = :2,
-			MOD_AGENT = :3
-		WHERE JNO = :4 
-		AND TRUNC(TBM_DATE) = TRUNC(:5)
-		AND DEPARTMENT = :6`
+		INSERT INTO IRIS_DEDUCTION_SET(SNO, USER_NM, DEPARTMENT, GENDER, REG_NO, PHONE, IN_RECOG_TIME, OUT_RECOG_TIME, RECORD_DATE, DEDUCT_ORDER, REG_DATE, REG_USER, REG_UNO, REG_AGENT)
+		VALUES(:1, :2, :3, :4, :5, :6, :7, :8, :9, :10, SYSDATE, :11, :12, :13)`
 
-	if _, err := tx.ExecContext(ctx, query, tbm.RegUser, tbm.RegUno, agent, tbm.Jno, tbm.TbmDate, tbm.Department); err != nil {
-		return fmt.Errorf("ModifyTbmExcel: %w", err)
+	for _, tbm := range tbms {
+		if _, err := tx.ExecContext(ctx, query, tbm.Sno, tbm.UserNm, tbm.Department, tbm.Gender, tbm.RegNo, tbm.Phone, tbm.InRecogTime, tbm.OutRecogTime, tbm.RecordDate, tbm.DeductOrder, tbm.RegUser, tbm.RegUno, agent); err != nil {
+			return fmt.Errorf("AddDeductionExcel: %w", err)
+		}
 	}
 	return nil
 }

--- a/csm-api/store/store_project.go
+++ b/csm-api/store/store_project.go
@@ -827,6 +827,25 @@ func (r *Repository) GetNonUsedProjectCount(ctx context.Context, db Queryer, sea
 	return count, nil
 }
 
+// 현장별 프로젝트 조회
+func (r *Repository) GetProjectBySite(ctx context.Context, db Queryer, sno int64) (entity.ProjectInfos, error) {
+	var list entity.ProjectInfos
+
+	query := `
+		SELECT 
+			T1.SNO,
+			T1.JNO,
+			T2.JOB_NAME	AS PROJECT_NM
+		FROM IRIS_SITE_JOB T1
+		LEFT JOIN SYS_JOB_INFO T2 ON T1.JNO = T2.JNO
+		WHERE T1.SNO = :1`
+
+	if err := db.SelectContext(ctx, &list, query, sno); err != nil {
+		return nil, fmt.Errorf("GetProjectBySite fail: %v", err)
+	}
+	return list, nil
+}
+
 // func: 현장 프로젝트 추가
 // @param
 // -

--- a/csm-api/utils/normalize.go
+++ b/csm-api/utils/normalize.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// 공백 제거 + 소문자 변환 + 특수문자 제거
+func NormalizeForEqual(s string) string {
+	re := regexp.MustCompile(`[^가-힣a-zA-Z0-9]`) // 한글, 영문, 숫자 외 제거
+	return strings.ToLower(re.ReplaceAllString(strings.TrimSpace(s), ""))
+}
+
+// yyyy-mm-dd -> yy-mm-dd
+func ConvertYYYYMMDDToYYMMDD(input string) string {
+	t, _ := time.Parse("2006-01-02", strings.TrimSpace(input))
+	return t.Format("06-01-02")
+}
+
+// mm-dd-yy -> yy-mm-dd
+func ConvertMMDDYYToYYMMDD(input string) string {
+	t, _ := time.Parse("01-02-06", strings.TrimSpace(input))
+	return t.Format("06-01-02")
+}

--- a/csm-api/utils/parse.go
+++ b/csm-api/utils/parse.go
@@ -49,3 +49,18 @@ func ParseNullTime(s string) null.Time {
 
 	return null.NewTime(t, true)
 }
+
+func ParseNullDateTime(dateStr, timeStr string) null.Time {
+	if dateStr == "" || timeStr == "" {
+		return null.NewTime(time.Time{}, false)
+	}
+
+	combined := dateStr + " " + timeStr
+	loc := time.Now().Location()
+	t, err := time.ParseInLocation("2006-01-02 15:04:05", combined, loc)
+	if err != nil {
+		return null.NewTime(time.Time{}, false)
+	}
+
+	return null.NewTime(t, true)
+}


### PR DESCRIPTION
1. 일일 근로자 비교시 생년월일, 성별, 핸드폰 번호도 비교하도록 수정
2. 일일 근로자 데이터 조회시 프로젝트 기준에서 현장기준으로 변경 -> 반영되지 않은 TBM, 퇴직공제는 프로젝트에 대한 정보가 없기에 현장기준으로 조회 -> 반영이 안된 근로자일 경우 같은 현장의 모든 프로젝트가 조회되도록 수정
3. 현장별 프로젝트 조회 로직 추가
4. 퇴직공제 엑셀 저장 및 데이터 파싱/DB저장 로직 추가
5. 서비스 레이어가 아닌 핸들러 레이어에서 DB 트랜잭션을 제어하기 위한 `transcation.go` 트랜잭션 context 작성