### PR TITLE
현장근로자

### DIFF
--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -49,6 +49,7 @@ type WorkerDaily struct {
 	AfterJno        null.Int    `json:"after_jno" db:"AFTER_JNO"`
 	BeforeState     null.String `json:"before_state" db:"BEFORE_STATE"`
 	AfterState      null.String `json:"after_state" db:"AFTER_STATE"`
+	Message         null.String `json:"message" db:"MESSAGE"`
 	Base
 }
 type WorkerDailys []*WorkerDaily

--- a/csm-api/init.go
+++ b/csm-api/init.go
@@ -5,10 +5,8 @@ import (
 	"csm-api/clock"
 	"csm-api/service"
 	"csm-api/store"
-	"fmt"
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/sync/errgroup"
-	"log"
 )
 
 /**
@@ -17,7 +15,6 @@ import (
  * @modified 최종 수정일:
  * @modifiedBy 최종 수정자:
  * @description: 서버 실행시 초기화를 위한 설정
- * - 현장 근로자 마감처리 (당일 이전 날짜 중에서 퇴근을 한 근로자들만 마감처리)
  */
 type Init struct {
 	WorkerService service.WorkerService
@@ -41,10 +38,12 @@ func (i *Init) RunInitializations(ctx context.Context) (err error) {
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		if err = i.WorkerService.ModifyWorkerDeadlineInit(ctx); err != nil {
-			return fmt.Errorf("[init] RunInitializations fail: %w", err)
-		}
-		log.Println("[init] ModifyWorkerDeadlineInit completed")
+		// 현장 근로자 마감처리 (당일 이전 날짜 중에서 퇴근을 한 근로자들만 마감처리)
+		// 필요시 주석 제거
+		//if err = i.WorkerService.ModifyWorkerDeadlineInit(ctx); err != nil {
+		//	return fmt.Errorf("[init] RunInitializations fail: %w", err)
+		//}
+		//log.Println("[init] ModifyWorkerDeadlineInit completed")
 		return nil
 	})
 

--- a/csm-api/service/service_worker.go
+++ b/csm-api/service/service_worker.go
@@ -215,8 +215,15 @@ func (s *ServiceWorker) MergeSiteBaseWorker(ctx context.Context, workers entity.
 			}
 		}
 	}()
+
+	// 추가/수정
 	if err = s.Store.MergeSiteBaseWorker(ctx, tx, workers); err != nil {
 		//TODO: 에러 아카이브
+		return fmt.Errorf("service_worker/MergeSiteBaseWorker err: %v", err)
+	}
+
+	// 변경사항 로그 저장
+	if err = s.Store.MergeSiteBaseWorkerLog(ctx, tx, workers); err != nil {
 		return fmt.Errorf("service_worker/MergeSiteBaseWorker err: %v", err)
 	}
 
@@ -271,11 +278,22 @@ func (s *ServiceWorker) ModifyWorkerProject(ctx context.Context, workers entity.
 			}
 		}
 	}()
+	// 전체 근로자 프로젝트 변경
+	if err = s.Store.ModifyWorkerDefaultProject(ctx, tx, workers); err != nil {
+		return fmt.Errorf("service_worker/ModifyWorkerDefaultProject err: %v", err)
+	}
 
+	// 현장 근로자 프로젝트 변경
 	if err = s.Store.ModifyWorkerProject(ctx, tx, workers); err != nil {
 		//TODO: 에러 아카이브
 		return fmt.Errorf("service_worker/ModifyWorkerProject err: %v", err)
 	}
+
+	// 현장근로자 로그 저장
+	if err = s.Store.MergeSiteBaseWorkerLog(ctx, tx, workers); err != nil {
+		return fmt.Errorf("service_worker/MergeSiteBaseWorker err: %v", err)
+	}
+
 	return
 }
 

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -114,8 +114,10 @@ type WorkerStore interface {
 	GetWorkerSiteBaseList(ctx context.Context, db Queryer, page entity.PageSql, search entity.WorkerDaily, retry string) (*entity.WorkerDailys, error)
 	GetWorkerSiteBaseCount(ctx context.Context, db Queryer, search entity.WorkerDaily, retry string) (int, error)
 	MergeSiteBaseWorker(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	MergeSiteBaseWorkerLog(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyWorkerDeadline(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyWorkerProject(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	ModifyWorkerDefaultProject(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyWorkerDeadlineInit(ctx context.Context, tx Execer) error
 	GetWorkerOverTime(ctx context.Context, db Queryer) (*entity.WorkerOverTimes, error)
 	ModifyWorkerOverTime(ctx context.Context, tx Execer, workerOverTime entity.WorkerOverTime) error


### PR DESCRIPTION
1. 현장근로자 수동 추가시 비교반영 컬럼값 'X', 추가한 근로자도 조회되도록 쿼리 조건 수정
2. 현장근로자 프로젝트 변경시 같은 현장내 프로젝트일 경우 전체근로자의 프로젝트도 수정
3. 현장근로자 변경사항(추가/수정) 로그 저장 추가