### PR TITLE
현장근로자 기능 추가

### DIFF
--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -43,7 +43,7 @@ type WorkerDaily struct {
 	IsDeadline      null.String `json:"is_deadline" db:"IS_DEADLINE"`
 	IsOvertime      null.String `json:"is_overtime" db:"IS_OVERTIME"`
 	CompareState    null.String `json:"compare_state" db:"COMPARE_STATE"`
-	WorkHours       null.Float  `json:"work_hours" db:"WORK_HOURS"`
+	WorkHour        null.Float  `json:"work_hour" db:"WORK_HOUR"`
 	SearchStartTime null.String `json:"search_start_time" db:"SEARCH_START_TIME"`
 	SearchEndTime   null.String `json:"search_end_time" db:"SEARCH_END_TIME"`
 	AfterJno        null.Int    `json:"after_jno" db:"AFTER_JNO"`

--- a/csm-api/handler/handler_worker.go
+++ b/csm-api/handler/handler_worker.go
@@ -313,3 +313,47 @@ func (h *HandlerWorker) ModifyProject(w http.ResponseWriter, r *http.Request) {
 
 	SuccessResponse(ctx, w)
 }
+
+// func: 현장근로자 삭제
+// @param
+// - http method: post
+// - param: entity.WorkerDailys - json(raw)
+func (h *HandlerWorker) SiteBaseRemove(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	//데이터 파싱
+	workers := entity.WorkerDailys{}
+	if err := json.NewDecoder(r.Body).Decode(&workers); err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+
+	err := h.Service.RemoveSiteBaseWorkers(ctx, workers)
+	if err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+	SuccessResponse(ctx, w)
+}
+
+// func: 마감 취소
+// @param
+// - http method: post
+// - param: entity.WorkerDailys - json(raw)
+func (h *HandlerWorker) SiteBaseDeadlineCancel(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	//데이터 파싱
+	workers := entity.WorkerDailys{}
+	if err := json.NewDecoder(r.Body).Decode(&workers); err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+
+	err := h.Service.ModifyDeadlineCancel(ctx, workers)
+	if err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+	SuccessResponse(ctx, w)
+}

--- a/csm-api/route/route_worker.go
+++ b/csm-api/route/route_worker.go
@@ -19,15 +19,17 @@ func WorkerRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 		},
 	}
 
-	router.Get("/total", workerHandler.TotalList)                    // 전체근로자 조회
-	router.Get("/total/simple", workerHandler.AbsentList)            // 근로자 검색(현장근로자 추가시 사용)
-	router.Get("/total/depart", workerHandler.DepartList)            // 프로젝트 회사명 조회
-	router.Post("/total", workerHandler.Add)                         // 추가
-	router.Put("/total", workerHandler.Modify)                       // 수정
-	router.Get("/site-base", workerHandler.SiteBaseList)             // 현장근로자 조회
-	router.Post("/site-base", workerHandler.Merge)                   // 현장근로자 추가&수정
-	router.Post("/site-base/deadline", workerHandler.ModifyDeadline) // 현장근로자 마감처리
-	router.Post("/site-base/project", workerHandler.ModifyProject)   // 현장근로자 프로젝트 이동
+	router.Get("/total", workerHandler.TotalList)                                   // 전체근로자 조회
+	router.Get("/total/simple", workerHandler.AbsentList)                           // 근로자 검색(현장근로자 추가시 사용)
+	router.Get("/total/depart", workerHandler.DepartList)                           // 프로젝트 회사명 조회
+	router.Post("/total", workerHandler.Add)                                        // 추가
+	router.Put("/total", workerHandler.Modify)                                      // 수정
+	router.Get("/site-base", workerHandler.SiteBaseList)                            // 현장근로자 조회
+	router.Post("/site-base", workerHandler.Merge)                                  // 현장근로자 추가&수정
+	router.Post("/site-base/deadline", workerHandler.ModifyDeadline)                // 현장근로자 마감처리
+	router.Post("/site-base/project", workerHandler.ModifyProject)                  // 현장근로자 프로젝트 이동
+	router.Post("/site-base/delete", workerHandler.SiteBaseRemove)                  // 현장근로자 삭제
+	router.Post("/site-base/deadline-cancel", workerHandler.SiteBaseDeadlineCancel) // 마감 취소
 
 	return router
 }

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -118,6 +118,13 @@ type WorkerService interface {
 	ModifyWorkerProject(ctx context.Context, workers entity.WorkerDailys) error
 	ModifyWorkerDeadlineInit(ctx context.Context) error
 	ModifyWorkerOverTime(ctx context.Context) (int, error)
+	RemoveSiteBaseWorkers(ctx context.Context, workers entity.WorkerDailys) error
+	ModifyDeadlineCancel(ctx context.Context, workers entity.WorkerDailys) error
+}
+
+type WorkHourService interface {
+	ModifyWorkHour(ctx context.Context, user entity.Base) error
+	ModifyWorkHourByJno(ctx context.Context, jno int64, user entity.Base, ids []string) error
 }
 
 type CompanyService interface {

--- a/csm-api/service/service_work_hour.go
+++ b/csm-api/service/service_work_hour.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+)
+
+type ServiceWorkHour struct {
+	SafeDB  store.Queryer
+	SafeTDB store.Beginner
+	Store   store.WorkHourStore
+}
+
+// 특정 프로젝트 및 근로자의 공수 계산: jno는 필수, ids는 없으면 jno의 모든 근로자 계산 있으면 해당 id의 근로자만 계산
+func (s *ServiceWorkHour) ModifyWorkHourByJno(ctx context.Context, jno int64, user entity.Base, ids []string) (err error) {
+	tx, err := s.SafeTDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("service_work_hour.ModifyWorkHourByJno BeginTx err: %v", err)
+	}
+
+	defer func() {
+		if err != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				err = fmt.Errorf("service_work_hour.ModifyWorkHourByJno err: %v; rollback err: %v", err, rollbackErr)
+			}
+		} else {
+			if commitErr := tx.Commit(); commitErr != nil {
+				err = fmt.Errorf("service_work_hour.ModifyWorkHourByJno err: %v; commit err: %v", err, commitErr)
+			}
+		}
+	}()
+
+	err = s.Store.ModifyWorkHourByJno(ctx, tx, jno, user, ids)
+	if err != nil {
+		//TODO: 에러 아카이브
+		return fmt.Errorf("service_work_hour.ModifyWorkHourByJno err: %v", err)
+	}
+	return
+}
+
+// 출퇴근이 둘다 있는 모든 근로자의 공수 계산
+func (s *ServiceWorkHour) ModifyWorkHour(ctx context.Context, user entity.Base) (err error) {
+	tx, err := s.SafeTDB.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("service_work_hour.ModifyWorkHour BeginTx err: %v", err)
+	}
+
+	defer func() {
+		if err != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				err = fmt.Errorf("service_work_hour.ModifyWorkHour err: %v; rollback err: %v", err, rollbackErr)
+			}
+		} else {
+			if commitErr := tx.Commit(); commitErr != nil {
+				err = fmt.Errorf("service_work_hour.ModifyWorkHour err: %v; commit err: %v", err, commitErr)
+			}
+		}
+	}()
+
+	err = s.Store.ModifyWorkHour(ctx, tx, user)
+	if err != nil {
+		//TODO: 에러 아카이브
+		return fmt.Errorf("service_work_hour.ModifyWorkHour err: %v", err)
+	}
+	return
+}

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -129,6 +129,13 @@ type WorkerStore interface {
 	GetWorkerOverTime(ctx context.Context, db Queryer) (*entity.WorkerOverTimes, error)
 	ModifyWorkerOverTime(ctx context.Context, tx Execer, workerOverTime entity.WorkerOverTime) error
 	DeleteWorkerOverTime(ctx context.Context, tx Execer, cno null.Int) error
+	RemoveSiteBaseWorkers(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	ModifyDeadlineCancel(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+}
+
+type WorkHourStore interface {
+	ModifyWorkHour(ctx context.Context, tx Execer, user entity.Base) error
+	ModifyWorkHourByJno(ctx context.Context, tx Execer, jno int64, user entity.Base, ids []string) error
 }
 
 type CompanyStore interface {

--- a/csm-api/store/store_project_setting.go
+++ b/csm-api/store/store_project_setting.go
@@ -21,7 +21,6 @@ func (r *Repository) GetManHourList(ctx context.Context, db Queryer, jno int64) 
 			FROM 
 			    IRIS_MAN_HOUR MH
 			WHERE
-			    MH.DEL_YN = 'N' AND
 				MH.JNO = :1
 			ORDER BY
 			    WORK_HOUR ASC
@@ -51,7 +50,6 @@ func (r *Repository) MergeManHour(ctx context.Context, tx Execer, manHour entity
 			FROM DUAL
 		) J2
 		ON (
-			J1.DEL_YN = 'N' AND
 			J1.MHNO = J2.MHNO
 		) WHEN MATCHED THEN
 			UPDATE SET

--- a/csm-api/store/store_work_hour.go
+++ b/csm-api/store/store_work_hour.go
@@ -1,0 +1,194 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"fmt"
+	"strings"
+)
+
+// 마감처리가 안된 특정프로젝트의 근로자의 공수 계산: jno는 필수, ids는 없으면 jno의 모든 근로자 계산 있으면 해당 id의 근로자만 계산
+func (r *Repository) ModifyWorkHourByJno(ctx context.Context, tx Execer, jno int64, user entity.Base, ids []string) error {
+	var (
+		query strings.Builder
+		args  []interface{}
+	)
+
+	args = append(args, jno)
+
+	query.WriteString(`
+			MERGE INTO IRIS_WORKER_DAILY_SET T1
+			USING (
+				SELECT 
+					T1.ROWID AS W_ROWID,
+					T1.JNO,
+					T1.RECORD_DATE,
+					T1.IN_RECOG_TIME,
+					T1.OUT_RECOG_TIME,
+					T1.IS_OVERTIME,
+					T2.IN_TIME,
+					T2.OUT_TIME,
+					T2.RESPITE_TIME,
+					TO_CHAR(T2.IN_TIME + NUMTODSINTERVAL(T2.RESPITE_TIME, 'MINUTE'), 'HH24:MI') AS IN_LIMIT,
+					TO_CHAR(T2.OUT_TIME - NUMTODSINTERVAL(T2.RESPITE_TIME, 'MINUTE'), 'HH24:MI') AS OUT_LIMIT,
+					TO_CHAR(T1.IN_RECOG_TIME, 'HH24:MI') AS ACTUAL_IN,
+					TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI') AS ACTUAL_OUT,
+					FLOOR((
+						(
+							CASE 
+								WHEN T1.IS_OVERTIME = 'Y' 
+								THEN TO_DATE(TO_CHAR(T1.RECORD_DATE + 1, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+								ELSE TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+							END
+							-
+							GREATEST(
+								TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.IN_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI'),
+								TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T2.IN_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+							)
+							-
+							GREATEST(
+								LEAST(
+									CASE 
+										WHEN T1.IS_OVERTIME = 'Y' 
+										THEN TO_DATE(TO_CHAR(T1.RECORD_DATE + 1, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+										ELSE TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+									END,
+									TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' 13:00', 'YYYY-MM-DD HH24:MI')
+								)
+								-
+								GREATEST(
+									GREATEST(
+										TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.IN_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI'),
+										TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T2.IN_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+									),
+									TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' 12:00', 'YYYY-MM-DD HH24:MI')
+								),
+								0
+							)
+						) * 24
+					)) AS WORKED_HOUR
+				FROM IRIS_WORKER_DAILY_SET T1
+				JOIN IRIS_JOB_SET T2 ON T1.JNO = T2.JNO
+				WHERE 
+					TRUNC(T1.RECORD_DATE) < TRUNC(SYSDATE)
+					AND T1.IN_RECOG_TIME IS NOT NULL
+					AND T1.OUT_RECOG_TIME IS NOT NULL
+					AND T1.JNO = :1
+					AND T1.IS_DEADLINE = 'N'`)
+
+	if len(ids) > 0 {
+		query.WriteString("\nAND T1.USER_ID IN (")
+		for i, id := range ids {
+			if i > 0 {
+				query.WriteString(", ")
+			}
+			query.WriteString(fmt.Sprintf(":%d", i+2))
+			args = append(args, id)
+		}
+		query.WriteString(")")
+	}
+
+	modUserIndex := len(args) + 1
+	modUnoIndex := modUserIndex + 1
+
+	args = append(args, user.ModUser, user.ModUno)
+
+	query.WriteString(fmt.Sprintf(`
+			) T3
+			ON (T1.ROWID = T3.W_ROWID)
+			WHEN MATCHED THEN
+			UPDATE SET 
+				T1.WORK_HOUR = (
+					CASE
+						WHEN T3.ACTUAL_IN <= T3.IN_LIMIT 
+						 AND T3.ACTUAL_OUT >= T3.OUT_LIMIT THEN 1.0
+						ELSE (
+							SELECT NVL(MAX(T4.MAN_HOUR), 0)
+							FROM IRIS_MAN_HOUR T4
+							WHERE 
+								T4.JNO = T3.JNO
+								AND T4.WORK_HOUR <= T3.WORKED_HOUR
+						)
+					END
+				),
+				T1.MOD_DATE = SYSDATE,
+				T1.MOD_USER = %d,
+				T1.MOD_UNO  = %d`, modUserIndex, modUnoIndex))
+
+	if _, err := tx.ExecContext(ctx, query.String(), args...); err != nil {
+		return fmt.Errorf("ModifyWorkHourByJno fail %w", err)
+	}
+	return nil
+}
+
+// 마감처이가 안되고 출퇴근이 둘다 있는 모든 근로자의 공수 계산
+func (r *Repository) ModifyWorkHour(ctx context.Context, tx Execer, user entity.Base) error {
+
+	query := `
+			MERGE INTO IRIS_WORKER_DAILY_SET T1
+			USING (
+				SELECT 
+					T1.ROWID AS W_ROWID,
+					T1.JNO,
+					T1.USER_ID,
+					T1.RECORD_DATE,
+					T1.IN_RECOG_TIME,
+					T1.OUT_RECOG_TIME,
+					T1.IS_OVERTIME,
+					T2.IN_TIME,
+					T2.OUT_TIME,
+					T2.RESPITE_TIME,
+					TO_CHAR(T2.IN_TIME + NUMTODSINTERVAL(T2.RESPITE_TIME, 'MINUTE'), 'HH24:MI') AS IN_LIMIT,
+					TO_CHAR(T2.OUT_TIME - NUMTODSINTERVAL(T2.RESPITE_TIME, 'MINUTE'), 'HH24:MI') AS OUT_LIMIT,
+					TO_CHAR(T1.IN_RECOG_TIME, 'HH24:MI') AS ACTUAL_IN,
+					TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI') AS ACTUAL_OUT,
+					GREATEST(
+						TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.IN_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI'),
+						TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T2.IN_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+					) AS IN_DATETIME,
+					CASE 
+						WHEN T1.IS_OVERTIME = 'Y' 
+						THEN TO_DATE(TO_CHAR(T1.RECORD_DATE + 1, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+						ELSE TO_DATE(TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') || ' ' || TO_CHAR(T1.OUT_RECOG_TIME, 'HH24:MI'), 'YYYY-MM-DD HH24:MI')
+					END AS OUT_DATETIME
+			
+				FROM IRIS_WORKER_DAILY_SET T1
+				JOIN IRIS_JOB_SET T2 ON T1.JNO = T2.JNO
+				WHERE 
+					TRUNC(T1.RECORD_DATE) < TRUNC(SYSDATE)
+					AND T1.IN_RECOG_TIME IS NOT NULL
+					AND T1.OUT_RECOG_TIME IS NOT NULL
+					AND T1.IS_DEADLINE = 'N'
+			) T3
+			ON (T1.ROWID = T3.W_ROWID)
+			WHEN MATCHED THEN
+			UPDATE SET 
+				T1.WORK_HOUR = (
+					CASE
+						WHEN T3.ACTUAL_IN <= T3.IN_LIMIT 
+						 AND T3.ACTUAL_OUT >= T3.OUT_LIMIT THEN 1.0
+						ELSE (
+							SELECT NVL(MAX(T4.MAN_HOUR), 0)
+							FROM IRIS_MAN_HOUR T4
+							WHERE 
+								T4.JNO = T3.JNO
+								AND T4.WORK_HOUR <= FLOOR((
+									(T3.OUT_DATETIME - T3.IN_DATETIME)
+									- GREATEST(
+										LEAST(T3.OUT_DATETIME, TO_DATE(TO_CHAR(T3.RECORD_DATE, 'YYYY-MM-DD') || ' 13:00', 'YYYY-MM-DD HH24:MI'))
+										- GREATEST(T3.IN_DATETIME, TO_DATE(TO_CHAR(T3.RECORD_DATE, 'YYYY-MM-DD') || ' 12:00', 'YYYY-MM-DD HH24:MI')),
+										0
+									)
+								) * 24)
+						)
+					END
+				),
+				T1.MOD_DATE = SYSDATE,
+				T1.MOD_USER = :1,
+				T1.MOD_UNO  = :2`
+
+	if _, err := tx.ExecContext(ctx, query, user.ModUser, user.ModUno); err != nil {
+		return fmt.Errorf("ModifyWorkHour fail %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
1. 현장 근로자 공수 계산 및 조회/수정 쿼리 작성
2. 자정, 서버실행 마다 이전 날짜 근로자의 공수가 계산되도록 추가
3. 근로자 삭제 기능 추가
4. 근로자 마감 취소 기능 추가
5. 현장 근로자에서 일어나는 모든 로직에 로그 테이블 저장 추가