### PR TITLE
[프로젝트 설정] 공수 수정 시 모두 삭제 후 추가하는 방식으로 변경

### DIFF
--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -60,6 +60,7 @@ type ProjectStore interface {
 type ProjectSettingStore interface {
 	GetManHourList(ctx context.Context, db Queryer, jno int64) (*entity.ManHours, error)
 	MergeManHour(ctx context.Context, tx Execer, manHour entity.ManHour) (int64, error)
+	AddManHour(ctx context.Context, tx Execer, manHour entity.ManHour) error
 	MergeProjectSetting(ctx context.Context, tx Execer, project entity.ProjectSetting) (int64, error)
 	GetCheckProjectSetting(ctx context.Context, db Queryer) (*entity.ProjectSettings, error)
 	GetProjectSetting(ctx context.Context, db Queryer, jno int64) (*entity.ProjectSettings, error)

--- a/csm-api/store/store_project_setting.go
+++ b/csm-api/store/store_project_setting.go
@@ -86,6 +86,22 @@ func (r *Repository) MergeManHour(ctx context.Context, tx Execer, manHour entity
 	return count, nil
 }
 
+// func: 공수 추가
+// @param
+// - manHour: 공수 정보
+func (r *Repository) AddManHour(ctx context.Context, tx Execer, manHour entity.ManHour) error {
+	query := `
+			INSERT INTO IRIS_MAN_HOUR ( WORK_HOUR, MAN_HOUR, JNO, ETC, REG_UNO, REG_USER, REG_DATE )
+			VALUES (:1, :2,	:3,	:4,	:5,	:6,	SYSDATE )
+		`
+	_, err := tx.ExecContext(ctx, query, manHour.WorkHour, manHour.ManHour, manHour.Jno, manHour.Etc, manHour.RegUno, manHour.RegUser)
+	if err != nil {
+		//TODO: 에러 아카이브
+		return fmt.Errorf("Store/AddManHour err: %w", err)
+	}
+	return nil
+}
+
 // func: 프로젝트 설정 정보 수정
 // @param: ProjectSetting
 // -


### PR DESCRIPTION
1.  공수 수정 시 해당 프로젝트의 공수를 모두 삭제한 후 추가하는 방식으로 변경.
    - jno로 해당하는 공수 모두 조회하여 삭제 및 로그
    - 값으로 넘겨 받은 공수 정보 새로 추가

2. addManhour() 메서드 생성
   - 수정 또는 추가가 아닌 추가만 하기 때문에 merge into 방식보다 insert 방식이 적합하다고 생각하여, inster를 이용하여 쿼리 작성

3. 로그는 add의 경우에는 front에서 받아오고, delete의 경우에는 back에서 값을 넣어줌.
   - delete의 경우는 back에서 조회하고 해당하는 값에 message를 넣어주기 때문에 이렇게 구성