### PR TITLE
[공지사항] 관리자 권한 부여 및 조직도 관련 테이블 시노님로 변경

### DIFF
--- a/csm-api/service/service_notice.go
+++ b/csm-api/service/service_notice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"csm-api/entity"
 	"csm-api/store"
+	"csm-api/utils"
 	"fmt"
 	"github.com/guregu/null"
 )
@@ -27,8 +28,11 @@ func (s *ServiceNotice) GetNoticeList(ctx context.Context, uno null.Int, role nu
 		return nil, fmt.Errorf("service_notice/GetNoticeList err : %w", err)
 	}
 
+	// 권한에 따라서 본인이 속한 jno를 불러올지 말지 query에 지정되어 있음.
 	var roleInt int
-	if role.String == "ADMIN" {
+	authorizationList := []string{"ADMIN", "SUPER_ADMIN", "SYSTEM_ADMIN"}
+
+	if utils.AuthorizationListCheck(authorizationList, role) {
 		roleInt = 1
 	} else {
 		roleInt = 0
@@ -48,7 +52,9 @@ func (s *ServiceNotice) GetNoticeList(ctx context.Context, uno null.Int, role nu
 func (s *ServiceNotice) GetNoticeListCount(ctx context.Context, uno null.Int, role null.String, search entity.Notice) (int, error) {
 
 	var roleInt int
-	if role.String == "ADMIN" {
+	authorizationList := []string{"ADMIN", "SUPER_ADMIN", "SYSTEM_ADMIN"}
+
+	if utils.AuthorizationListCheck(authorizationList, role) {
 		roleInt = 1
 	} else {
 		roleInt = 0

--- a/csm-api/service/service_project.go
+++ b/csm-api/service/service_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"csm-api/entity"
 	"csm-api/store"
+	"csm-api/utils"
 	"database/sql"
 	"fmt"
 	"strconv"
@@ -252,7 +253,8 @@ func (p *ServiceProject) GetProjectNmUnoList(ctx context.Context, uno int64, rol
 	}
 
 	var roleInt int
-	if role == "ADMIN" {
+	authorizationList := []string{"ADMIN", "SUPER_ADMIN", "SYSTEM_ADMIN"}
+	if utils.AuthorizationListCheck(authorizationList, utils.ParseNullString(role)) {
 		roleInt = 1
 	} else {
 		roleInt = 0

--- a/csm-api/store/store_notice.go
+++ b/csm-api/store/store_notice.go
@@ -78,7 +78,7 @@ func (r *Repository) GetNoticeList(ctx context.Context, db Queryer, uno null.Int
 						N.IS_USE = 'Y'
 						AND N.POSTING_START_DATE <= SYSDATE
 						AND N.POSTING_END_DATE > SYSDATE
-						AND (N.JNO IN (SELECT DISTINCT(JNO) FROM TIMESHEET.JOB_MEMBER_LIST WHERE 1 = :1 OR UNO = :2) OR N.JNO = 0 )
+						AND (N.JNO IN (SELECT DISTINCT(JNO) FROM S_JOB_MEMBER_LIST WHERE 1 = :1 OR UNO = :2) OR N.JNO = 0)
 				)
 				SELECT * 
 			  	FROM (
@@ -87,6 +87,7 @@ func (r *Repository) GetNoticeList(ctx context.Context, db Queryer, uno null.Int
 						SELECT *
 						FROM Notice
 						WHERE
+							JNO = 0 OR
 							%s
 						ORDER BY
 							%s,
@@ -157,11 +158,12 @@ func (r *Repository) GetNoticeListCount(ctx context.Context, db Queryer, uno nul
 					N.IS_USE = 'Y'
 					AND N.POSTING_START_DATE <= SYSDATE
 					AND N.POSTING_END_DATE > SYSDATE
-					AND (N.JNO IN (SELECT DISTINCT(JNO) FROM TIMESHEET.JOB_MEMBER_LIST WHERE 1 = :1 OR UNO = :2) OR N.JNO = 0 )
+					AND (N.JNO IN (SELECT DISTINCT(JNO) FROM S_JOB_MEMBER_LIST WHERE 1 = :1 OR UNO = :2) OR N.JNO = 0)
 			)
 			SELECT COUNT(*) 
 			FROM  Notice
 			WHERE
+				
 				%s`, condition)
 
 	if err := db.GetContext(ctx, &count, query, role, uno); err != nil {

--- a/csm-api/store/store_organization.go
+++ b/csm-api/store/store_organization.go
@@ -28,9 +28,9 @@ func (r *Repository) GetOrganizationClientList(ctx context.Context, db Queryer, 
 					CASE WHEN LENGTH(JM.CELL) > 6 THEN  JM.CELL ELSE '' END CELL, 
 					CASE WHEN LENGTH(JM.TEL) > 6 THEN  JM.TEL ELSE '' END TEL	
 				FROM 
-					JOB_MEMBER_LIST JM 
+					S_JOB_MEMBER_LIST JM 
 				INNER JOIN 
-					JOB_INFO J 
+					S_JOB_INFO J 
 				ON 
 					J.JNO = JM.JNO
 				INNER JOIN 
@@ -56,7 +56,7 @@ func (r *Repository) GetOrganizationHtencList(ctx context.Context, db Queryer, j
 
 	query := fmt.Sprintf(`
 					WITH MEMBER_LIST AS (
-						SELECT * FROM JOB_MEMBER_LIST
+						SELECT * FROM S_JOB_MEMBER_LIST
 						WHERE JNO = :1
 					)
 					,HITECH AS (

--- a/csm-api/store/store_project.go
+++ b/csm-api/store/store_project.go
@@ -261,7 +261,7 @@ func (r *Repository) GetProjectSafeWorkerCountList(ctx context.Context, db Query
 				  WHERE t1.AUTH = 'SAFETY_MANAGER'
 				  UNION
 				  SELECT t1.JNO, USER_NAME
-				  FROM TIMESHEET.JOB_MEMBER_LIST t1
+				  FROM S_JOB_MEMBER_LIST t1
 				  JOIN S_SYS_USER_SET t2 ON t2.UNO = t1.UNO
 				  WHERE t1.COMP_TYPE = 'H'
 					AND t1.FUNC_CODE = 510
@@ -618,7 +618,7 @@ func (r *Repository) GetStaffProjectList(ctx context.Context, db Queryer, pageSq
 					FROM 
 						S_JOB_INFO J 
 					INNER JOIN 
-						(SELECT * FROM TIMESHEET.JOB_MEMBER_LIST WHERE UNO = :1) JM 
+						(SELECT * FROM S_JOB_MEMBER_LIST WHERE UNO = :1) JM 
 					ON 
 						J.JNO = JM.JNO
 					LEFT JOIN
@@ -666,7 +666,7 @@ func (r *Repository) GetStaffProjectCount(ctx context.Context, db Queryer, searc
 					COUNT(*)
 				FROM S_JOB_INFO J 
 				INNER JOIN 
-					(SELECT * FROM TIMESHEET.JOB_MEMBER_LIST WHERE UNO = :1) JM 
+					(SELECT * FROM S_JOB_MEMBER_LIST WHERE UNO = :1) JM 
 				ON 
 					J.JNO = JM.JNO 
 				INNER JOIN 
@@ -699,7 +699,7 @@ func (r *Repository) GetProjectNmUnoList(ctx context.Context, db Queryer, uno sq
 			      JOB_STATE = 'Y' AND
 			      1=:1 OR 
 			      JNO IN (SELECT DISTINCT(JNO) 
-						  FROM TIMESHEET.JOB_MEMBER_LIST 
+						  FROM S_JOB_MEMBER_LIST 
 						  WHERE UNO = :2)
 			  ORDER BY 
 			      JNO DESC`

--- a/csm-api/utils/authorization.go
+++ b/csm-api/utils/authorization.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"github.com/guregu/null"
+	"golang.org/x/exp/slices"
+	"strings"
+)
+
+// func: 권한 슬라이스에서 role이 있는지 확인 후 있으면 ture값 반환, 없으면 false값 반환
+// @param
+// - list: 권한 담긴 슬라이스
+// - roles: 역할 문자열 (|로 나열된 것)
+func AuthorizationListCheck(list []string, roles null.String) bool {
+	check := false
+
+	for _, role := range strings.Split(roles.String, "|") {
+		role = strings.TrimSpace(role)
+		if slices.Contains(list, role) {
+			check = true
+		}
+	}
+
+	return check
+}


### PR DESCRIPTION
1. 테이블 시노님으로 변경
    - JOB_MEMBER_LIST 테이블을 S_JOB_MEMBER_LIST로 변경
    - JOB_INFO 테이블을 S_JOB_INFO로 변경

2. 공지사항 조회 시 전체공지와 본인이 속한 프로젝트만 볼 수 있도록 변경.
    - 프로젝트를 선택 시 전체공지는 항상 보이도록 설정

3. 관리자(ADMIN, SUPER_ADMIN, SYSTEM_ADMIN) 권한은 공지 전체를 볼 수 있도록 설정