### PR TITLE
추가/수정/삭제시 로그 파일 기록

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ csm-api.exe
 csm-api/.idea
 csm-api/excel_deduction
 csm-api/uploads
+csm-api/logs

--- a/csm-api/config/config.go
+++ b/csm-api/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	Port       int    `env:"PORT" envDefault:"8082"`
 	Domain     string `env:"DOMAIN" envDefault:"localhost"`
 	UploadPath string `env:"UPLOAD_PATH" envDefault:"uploads"`
+	LogPath    string `env:"LOG_PATH" envDefault:"logs"`
 }
 
 // caarlos0/env 패키지를 사용하여 struct의 envDefault값을 환경변수로 넘겨준다.

--- a/csm-api/config/config_prod.go
+++ b/csm-api/config/config_prod.go
@@ -31,4 +31,9 @@ func init() {
 	if err != nil {
 		log.Fatalf("Failed to set UPLOAD_PATH: %v", err)
 	}
+
+	err = os.Setenv("LOG_PATH", "tmp/data/csm/logs")
+	if err != nil {
+		log.Fatalf("Failed to set LOG_PATH: %v", err)
+	}
 }

--- a/csm-api/entity/log.go
+++ b/csm-api/entity/log.go
@@ -1,0 +1,100 @@
+package entity
+
+import (
+	"csm-api/config"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type ItemLogEntry struct {
+	Time     string                 `json:"time"`
+	Type     string                 `json:"type"`
+	Menu     string                 `json:"menu"`
+	UserName string                 `json:"user_name"`
+	UserUno  int64                  `json:"user_uno"`
+	Record   map[string]interface{} `json:"record"`
+	Item     map[string]interface{} `json:"item"`
+}
+
+func DecodeItem[T any](r *http.Request, model T) (*ItemLogEntry, T, error) {
+	var itemLog ItemLogEntry
+	var result T
+
+	// 1. 전체 요청 파싱
+	if err := json.NewDecoder(r.Body).Decode(&itemLog); err != nil {
+		return nil, result, err
+	}
+
+	// 2. itemLog.Item → JSON
+	b, err := json.Marshal(itemLog.Item)
+	if err != nil {
+		return &itemLog, result, err
+	}
+
+	// 3. JSON → 원하는 타입(T)
+	if err := json.Unmarshal(b, &result); err != nil {
+		return &itemLog, result, err
+	}
+
+	return &itemLog, result, nil
+}
+
+// 성공한 요청만 로그 파일에 기록 (에러는 콘솔 출력)
+func WriteLog(itemLog *ItemLogEntry) {
+	cfg, err := config.NewConfig()
+	if err != nil {
+		log.Printf("config.NewConfig() 실패: %v\n", err)
+		return
+	}
+
+	now := time.Now()
+	year := now.Format("2006") // ex: "2025"
+	month := now.Format("01")  // ex: "07"
+	day := now.Format("20060102")
+
+	// 로그 디렉토리: logs/2025/07
+	logDir := filepath.Join(cfg.LogPath, year, month)
+
+	if err := os.MkdirAll(logDir, os.ModePerm); err != nil {
+		log.Printf("로그 디렉토리 생성 실패 (%s): %v\n", logDir, err)
+		return
+	}
+
+	// 로그 파일 경로: logs/2025/07/csm_20250708.log
+	logFileName := fmt.Sprintf("csm_%s.log", day)
+	logFilePath := filepath.Join(logDir, logFileName)
+
+	// 로그 내용 구성 (item 제외)
+	logContent := map[string]interface{}{
+		"time":      itemLog.Time,
+		"type":      itemLog.Type,
+		"user_name": itemLog.UserName,
+		"user_uno":  itemLog.UserUno,
+		"menu":      itemLog.Menu,
+		"record":    itemLog.Record,
+	}
+
+	logJSON, err := json.MarshalIndent(logContent, "", "\t")
+	if err != nil {
+		log.Printf("로그 JSON 직렬화 실패: %v\n", err)
+		return
+	}
+
+	// 로그 파일에 이어쓰기
+	f, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		log.Printf("로그 파일 열기 실패 (%s): %v\n", logFilePath, err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(string(logJSON) + "\n"); err != nil {
+		log.Printf("로그 쓰기 실패 (%s): %v\n", logFilePath, err)
+		return
+	}
+}

--- a/csm-api/handler/handler_device.go
+++ b/csm-api/handler/handler_device.go
@@ -4,11 +4,8 @@ import (
 	"csm-api/entity"
 	"csm-api/service"
 	"csm-api/utils"
-	"encoding/json"
 	"net/http"
 	"strconv"
-
-	"github.com/go-chi/chi/v5"
 )
 
 /**
@@ -82,19 +79,16 @@ func (d *DeviceHandler) List(w http.ResponseWriter, r *http.Request) {
 func (d *DeviceHandler) Add(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	//response 데이터 파싱
-	device := entity.Device{}
-	if err := json.NewDecoder(r.Body).Decode(&device); err != nil {
-		FailResponse(ctx, w, err)
-		return
-	}
+	itemLog, device, err := entity.DecodeItem(r, entity.Device{})
 
 	// 근태인식기 추가
-	err := d.Service.AddDevice(ctx, device)
+	err = d.Service.AddDevice(ctx, device)
 	if err != nil {
 		FailResponse(ctx, w, err)
 		return
 	}
+
+	entity.WriteLog(itemLog)
 
 	SuccessResponse(ctx, w)
 }
@@ -105,45 +99,37 @@ func (d *DeviceHandler) Add(w http.ResponseWriter, r *http.Request) {
 func (d *DeviceHandler) Modify(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	//response 데이터 파싱
-	device := entity.Device{}
-	if err := json.NewDecoder(r.Body).Decode(&device); err != nil {
-		FailResponse(ctx, w, err)
-		return
-	}
+	itemLog, device, err := entity.DecodeItem(r, entity.Device{})
 
 	// 근태인식기 수정
-	err := d.Service.ModifyDevice(ctx, device)
+	err = d.Service.ModifyDevice(ctx, device)
 	if err != nil {
 		FailResponse(ctx, w, err)
 		return
 	}
+
+	entity.WriteLog(itemLog)
 
 	SuccessResponse(ctx, w)
 }
 
 // func: 근태인식기 삭제
 // @param
-// - response: url parameter
+// - response: post
 func (d *DeviceHandler) Remove(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	// URL에서 {id} 값을 가져오기
-	id := chi.URLParam(r, "id")
-	int64ID, err := strconv.ParseInt(id, 10, 64)
-	if err != nil {
-		FailResponse(ctx, w, err)
-		return
-	}
+	itemLog, device, err := entity.DecodeItem(r, entity.Device{})
 
 	// 서비스 호출하여 삭제 처리
-	err = d.Service.RemoveDevice(ctx, int64ID)
+	err = d.Service.RemoveDevice(ctx, device.Dno.Int64)
 	if err != nil {
 		FailResponse(ctx, w, err)
 		return
 	}
 
-	// 성공 응답
+	entity.WriteLog(itemLog)
+
 	SuccessResponse(ctx, w)
 }
 

--- a/csm-api/route/route_device.go
+++ b/csm-api/route/route_device.go
@@ -22,7 +22,7 @@ func DeviceRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 	router.Get("/", deviceHandler.List)                            // 조회
 	router.Post("/", deviceHandler.Add)                            // 추가
 	router.Put("/", deviceHandler.Modify)                          // 수정
-	router.Delete("/{id}", deviceHandler.Remove)                   // 삭제
+	router.Post("/delete", deviceHandler.Remove)                   // 삭제
 	router.Get("/check-registered", deviceHandler.CheckRegistered) // 장치 등록 확인
 
 	return router


### PR DESCRIPTION
파일 기록용 로그 구조체를 생성하여 기존에 사용하던 구조체는 로그구조체 내부에서 map형태로 받아서 json구조에 맞게 보내기만 한다면 어떤 형태의 구조체도 로그 구조체를 통하여 데이터를 받을 수 있도록 하기에 기존의 handler에서 수정이 크게 일어나지 않음

DELETE http method를 사용하는 경우에는 body에 값을 받아야 하기에 어쩔 수 없어 로그기록을 한다면 post로 변경해서 해야함.

받은 데이터를 csm_{yyyymmdd}.log 파일명으로 하여 하루기준으로 기록되고 연도, 월 기준의 디렉토리 내부에 생성이 됨.