### PR TITLE
협력업체 관리감독자 조회, 권한 부여 및 그 외

### DIFF
--- a/csm-api/auth/jwtUtils.go
+++ b/csm-api/auth/jwtUtils.go
@@ -20,17 +20,18 @@ type JWTUtils struct {
 type JWTRole string
 
 const (
-	SystemAdmin   JWTRole = "SYSTEM_ADMIN"
-	SuperAdmin    JWTRole = "SUPER_ADMIN"
-	Admin         JWTRole = "ADMIN"
-	SiteDirector  JWTRole = "SITE_DIRECTOR"
-	SiteManager   JWTRole = "SITE_MANAGER"
-	SafetyManager JWTRole = "SAFETY_MANAGER"
-	Supervisor    JWTRole = "SUPERVISOR"
-	CoManager     JWTRole = "CO_MANAGER"
-	Executive     JWTRole = "EXECUTIVE"
-	User          JWTRole = "USER"
-	CoUser        JWTRole = "CO_USER"
+	SystemAdmin     JWTRole = "SYSTEM_ADMIN"
+	SuperAdmin      JWTRole = "SUPER_ADMIN"
+	Admin           JWTRole = "ADMIN"
+	SiteDirector    JWTRole = "SITE_DIRECTOR"
+	SiteManager     JWTRole = "SITE_MANAGER"
+	TempSiteManager JWTRole = "TEMP_SITE_MANAGER"
+	SafetyManager   JWTRole = "SAFETY_MANAGER"
+	Supervisor      JWTRole = "SUPERVISOR"
+	CoManager       JWTRole = "CO_MANAGER"
+	Executive       JWTRole = "EXECUTIVE"
+	User            JWTRole = "USER"
+	CoUser          JWTRole = "CO_USER"
 )
 
 // claims 정의

--- a/csm-api/entity/company.go
+++ b/csm-api/entity/company.go
@@ -48,15 +48,18 @@ type Managers []*Manager
 
 // struct: Begin::관리감독자
 type Supervisor struct {
-	Uno       null.Int    `json:"uno" db:"UNO"`
-	Jno       null.Int    `json:"jno" db:"JNO"`
-	UserName  null.String `json:"user_name" db:"USER_NAME"`
-	UserId    null.String `json:"user_id" db:"USER_ID"`
-	DutyName  null.String `json:"duty_name" db:"DUTY_NAME"`
-	DutyCd    null.String `json:"duty_cd" db:"DUTY_CD"`
-	JobdutyId null.String `json:"jobduty_id" db:"JOBDUTY_ID"`
-	JoinDate  null.Time   `json:"join_date" db:"JOIN_DATE"`
-	FuncNo    null.String `json:"func_no" db:"FUNC_NO"`
+	Uno           null.Int    `json:"uno" db:"UNO"`
+	Jno           null.Int    `json:"jno" db:"JNO"`
+	UserName      null.String `json:"user_name" db:"USER_NAME"`
+	UserId        null.String `json:"user_id" db:"USER_ID"`
+	DutyName      null.String `json:"duty_name" db:"DUTY_NAME"`
+	DutyCd        null.String `json:"duty_cd" db:"DUTY_CD"`
+	JobdutyId     null.String `json:"jobduty_id" db:"JOBDUTY_ID"`
+	JoinDate      null.Time   `json:"join_date" db:"JOIN_DATE"`
+	FuncNo        null.String `json:"func_no" db:"FUNC_NO"`
+	CdNm          null.String `json:"cd_nm" db:"CD_NM"`
+	SysSafe       null.String `json:"sys_safe" db:"SYS_SAFE"`
+	IsSiteManager null.String `json:"is_site_manager" db:"IS_SITE_MANAGER"`
 }
 type Supervisors []*Supervisor
 

--- a/csm-api/entity/user_role_map.go
+++ b/csm-api/entity/user_role_map.go
@@ -1,0 +1,10 @@
+package entity
+
+import "github.com/guregu/null"
+
+type UserRoleMap struct {
+	UserUno  null.Int    `json:"user_uno" db:"USER_UNO"`
+	RoleCode null.String `json:"role_code" db:"ROLE_CODE"`
+	Jno      null.Int    `json:"jno" db:"JNO"`
+	Base
+}

--- a/csm-api/handler/handler_user_role.go
+++ b/csm-api/handler/handler_user_role.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"csm-api/entity"
+	"csm-api/service"
+	"net/http"
+	"strconv"
+)
+
+type HandlerUserRole struct {
+	Service service.UserRoleService
+}
+
+// 사용자 권한 조회
+// param HTTP GET uno (사용자번호)
+func (h *HandlerUserRole) GetUserRoleListByUno(w http.ResponseWriter, r *http.Request) {
+	unoString := r.URL.Query().Get("uno")
+	if unoString == "" {
+		BadRequestResponse(r.Context(), w)
+		return
+	}
+	uno, _ := strconv.ParseInt(unoString, 10, 64)
+	userRoles, err := h.Service.GetUserRoleListByUno(r.Context(), uno)
+	if err != nil {
+		FailResponse(r.Context(), w, err)
+	}
+	SuccessValuesResponse(r.Context(), w, userRoles)
+}
+
+// 사용자 권한 추가
+func (h *HandlerUserRole) AddUserRole(w http.ResponseWriter, r *http.Request) {
+	itemLog, userRoles, err := entity.DecodeItem(r, []entity.UserRoleMap{})
+	if err != nil {
+		FailResponse(r.Context(), w, err)
+		return
+	}
+
+	err = h.Service.AddUserRole(r.Context(), userRoles)
+	if err != nil {
+		FailResponse(r.Context(), w, err)
+		return
+	}
+
+	entity.WriteLog(itemLog)
+	SuccessResponse(r.Context(), w)
+}
+
+// 사용자 권한 삭제
+func (h *HandlerUserRole) RemoveUserRole(w http.ResponseWriter, r *http.Request) {
+	itemLog, userRoles, err := entity.DecodeItem(r, []entity.UserRoleMap{})
+	if err != nil {
+		FailResponse(r.Context(), w, err)
+		return
+	}
+
+	err = h.Service.RemoveUserRole(r.Context(), userRoles)
+	if err != nil {
+		FailResponse(r.Context(), w, err)
+		return
+	}
+
+	entity.WriteLog(itemLog)
+	SuccessResponse(r.Context(), w)
+}

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -81,6 +81,7 @@ func newMux(ctx context.Context, safeDb *sqlx.DB, timesheetDb *sqlx.DB) (http.Ha
 		router.Mount("/notice", route.NoticeRoute(safeDb, &r))                  // 공지사항
 		router.Mount("/code", route.CodeRoute(safeDb, &r))                      // 코드
 		router.Mount("/project-setting", route.ProjectSettingRoute(safeDb, &r)) // 프로젝트 설정
+		router.Mount("/user-role", route.UserRoleRoute(safeDb, &r))             // 사용자 권한
 	})
 
 	return c.Handler(mux), nil

--- a/csm-api/route/route_company.go
+++ b/csm-api/route/route_company.go
@@ -13,9 +13,10 @@ func CompanyRoute(safeDB *sqlx.DB, timeSheetDB *sqlx.DB, r *store.Repository) ch
 
 	companyHandler := handler.HandlerCompany{
 		Service: &service.ServiceCompany{
-			SafeDB:      safeDB,
-			TimeSheetDB: timeSheetDB,
-			Store:       r,
+			SafeDB:        safeDB,
+			TimeSheetDB:   timeSheetDB,
+			Store:         r,
+			UserRoleStore: r,
 		},
 	}
 

--- a/csm-api/route/route_user_role.go
+++ b/csm-api/route/route_user_role.go
@@ -1,0 +1,27 @@
+package route
+
+import (
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func UserRoleRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
+	router := chi.NewRouter()
+
+	userRoleHandler := &handler.HandlerUserRole{
+		Service: &service.ServiceUserRole{
+			SafeDB:  safeDB,
+			SafeTDB: safeDB,
+			Store:   r,
+		},
+	}
+
+	router.Get("/uno", userRoleHandler.GetUserRoleListByUno) // 사용자 권한 조회
+	router.Post("/add", userRoleHandler.AddUserRole)         // 사용자 권한 추가
+	router.Post("/remove", userRoleHandler.RemoveUserRole)   // 사용자 권한 삭제
+
+	return router
+}

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -187,3 +187,10 @@ type CompareService interface {
 	GetCompareList(ctx context.Context, compare entity.Compare, retry string, order string) ([]entity.Compare, error)
 	ModifyWorkerCompareApply(ctx context.Context, workers entity.WorkerDailys) error
 }
+
+type UserRoleService interface {
+	GetUserRoleListByUno(ctx context.Context, uno int64) ([]entity.UserRoleMap, error)
+	GetUserRoleListByCodeAndJno(ctx context.Context, code string, jno int64) ([]entity.UserRoleMap, error)
+	AddUserRole(ctx context.Context, userRoles []entity.UserRoleMap) error
+	RemoveUserRole(ctx context.Context, userRoles []entity.UserRoleMap) error
+}

--- a/csm-api/service/service_user_role.go
+++ b/csm-api/service/service_user_role.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/store"
+	"fmt"
+)
+
+type ServiceUserRole struct {
+	SafeDB  store.Queryer
+	SafeTDB store.Beginner
+	Store   store.UserRoleStore
+}
+
+// 사용자 권한 조회
+// param: 사용자번호
+func (s *ServiceUserRole) GetUserRoleListByUno(ctx context.Context, uno int64) ([]entity.UserRoleMap, error) {
+	list, err := s.Store.GetUserRoleListByUno(ctx, s.SafeDB, uno)
+	if err != nil {
+		return nil, fmt.Errorf("service_user_role/GetUserRoleListByUno err: %w", err)
+	}
+	return list, nil
+}
+
+// 사용자 권한 조회
+// param: 권한코드, 프로젝트 번호
+func (s *ServiceUserRole) GetUserRoleListByCodeAndJno(ctx context.Context, code string, jno int64) ([]entity.UserRoleMap, error) {
+	list, err := s.Store.GetUserRoleListByCodeAndJno(ctx, s.SafeDB, code, jno)
+	if err != nil {
+		return nil, fmt.Errorf("service_user_role/GetUserRoleListByCodeAndJno err: %w", err)
+	}
+	return list, nil
+}
+
+// 사용자 권한 추가
+func (s *ServiceUserRole) AddUserRole(ctx context.Context, userRoles []entity.UserRoleMap) (err error) {
+	tx, err := s.SafeTDB.BeginTx(ctx, nil)
+	if err != nil {
+		err = fmt.Errorf("service_user_role/AddUserRole BeginTx error: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				err = fmt.Errorf("service_user_role/AddUserRole Rollback error: %w", rollbackErr)
+			}
+		} else {
+			if commitErr := tx.Commit(); commitErr != nil {
+				err = fmt.Errorf("service_user_role/AddUserRole Commit error: %w", commitErr)
+			}
+		}
+	}()
+
+	if err = s.Store.AddUserRole(ctx, tx, userRoles); err != nil {
+		err = fmt.Errorf("service_user_role/AddUserRole error: %w", err)
+	}
+	return
+}
+
+// 사용자 권한 삭제
+func (s *ServiceUserRole) RemoveUserRole(ctx context.Context, userRoles []entity.UserRoleMap) (err error) {
+	tx, err := s.SafeTDB.BeginTx(ctx, nil)
+	if err != nil {
+		err = fmt.Errorf("service_user_role/RemoveUserRole BeginTx error: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				err = fmt.Errorf("service_user_role/RemoveUserRole Rollback error: %w", rollbackErr)
+			}
+		} else {
+			if commitErr := tx.Commit(); commitErr != nil {
+				err = fmt.Errorf("service_user_role/RemoveUserRole Commit error: %w", commitErr)
+			}
+		}
+	}()
+	if err = s.Store.RemoveUserRole(ctx, tx, userRoles); err != nil {
+		err = fmt.Errorf("service_user_role/RemoveUserRole error: %w", err)
+	}
+	return
+}

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -157,6 +157,7 @@ type CompanyStore interface {
 	GetSiteManagerList(ctx context.Context, db Queryer, jno sql.NullInt64) (*entity.Managers, error)
 	GetSafeManagerList(ctx context.Context, db Queryer, jno sql.NullInt64) (*entity.Managers, error)
 	GetSupervisorList(ctx context.Context, db Queryer, jno sql.NullInt64) (*entity.Supervisors, error)
+	GetConstruction(ctx context.Context, db Queryer, jno int64) (*entity.Supervisors, error)
 	GetWorkInfoList(ctx context.Context, db Queryer) (*entity.WorkInfos, error)
 	GetCompanyInfoList(ctx context.Context, db Queryer, jno sql.NullInt64) (*entity.CompanyInfos, error)
 	GetCompanyWorkInfoList(ctx context.Context, db Queryer, jno sql.NullInt64) (*entity.WorkInfos, error)
@@ -203,4 +204,11 @@ type ExcelStore interface {
 type WeatherStore interface {
 	SaveWeather(ctx context.Context, tx Execer, weather entity.Weather) error
 	GetWeatherList(ctx context.Context, db Queryer, sno int64, targetDate time.Time) (*entity.Weathers, error)
+}
+
+type UserRoleStore interface {
+	GetUserRoleListByUno(ctx context.Context, db Queryer, uno int64) ([]entity.UserRoleMap, error)
+	GetUserRoleListByCodeAndJno(ctx context.Context, db Queryer, code string, jno int64) ([]entity.UserRoleMap, error)
+	AddUserRole(ctx context.Context, tx Execer, userRoles []entity.UserRoleMap) error
+	RemoveUserRole(ctx context.Context, tx Execer, userRoles []entity.UserRoleMap) error
 }

--- a/csm-api/store/store_user_role.go
+++ b/csm-api/store/store_user_role.go
@@ -1,0 +1,80 @@
+package store
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/utils"
+	"fmt"
+)
+
+// 사용자 권한 조회
+// param: 사용자번호
+func (r *Repository) GetUserRoleListByUno(ctx context.Context, db Queryer, uno int64) ([]entity.UserRoleMap, error) {
+	var list []entity.UserRoleMap
+
+	query := `
+		SELECT 
+			USER_UNO,
+			ROLE_CODE,
+			JNO
+		FROM IRIS_USER_ROLE_MAP
+		WHERE USER_UNO = :1
+		AND JNO != 0`
+
+	if err := db.SelectContext(ctx, &list, query, uno); err != nil {
+		return nil, fmt.Errorf("GetUserRoleListByUno fail: %w", err)
+	}
+	return list, nil
+}
+
+// 사용자 권한 조회
+// param: 권한코드, 프로젝트번호
+func (r *Repository) GetUserRoleListByCodeAndJno(ctx context.Context, db Queryer, code string, jno int64) ([]entity.UserRoleMap, error) {
+	var list []entity.UserRoleMap
+
+	query := `
+		SELECT 
+			USER_UNO,
+			ROLE_CODE,
+			JNO
+		FROM IRIS_USER_ROLE_MAP
+		WHERE ROLE_CODE = :1
+		AND JNO = :2`
+
+	if err := db.SelectContext(ctx, &list, query, code, jno); err != nil {
+		return nil, fmt.Errorf("GetUserRoleListByCodeAndJno fail: %w", err)
+	}
+	return list, nil
+}
+
+// 사용자 권한 추가
+func (r *Repository) AddUserRole(ctx context.Context, tx Execer, userRoles []entity.UserRoleMap) error {
+	agent := utils.GetAgent()
+
+	query := `
+		INSERT INTO IRIS_USER_ROLE_MAP(USER_UNO, ROLE_CODE, JNO, REG_DATE, REG_AGENT, REG_USER, REG_UNO)
+		VALUES (:1, :2, :3, SYSDATE, :4, :5, :6)`
+
+	for _, userRole := range userRoles {
+		if _, err := tx.ExecContext(ctx, query, userRole.UserUno, userRole.RoleCode, userRole.Jno, agent, userRole.RegUser, userRole.RegUno); err != nil {
+			return fmt.Errorf("AddUserRole fail: %w", err)
+		}
+	}
+	return nil
+}
+
+// 사용자 권한 삭제
+func (r *Repository) RemoveUserRole(ctx context.Context, tx Execer, userRoles []entity.UserRoleMap) error {
+	query := `
+		DELETE FROM IRIS_USER_ROLE_MAP
+		WHERE USER_UNO = :1
+		AND ROLE_CODE = :2
+		AND JNO = :3`
+
+	for _, userRole := range userRoles {
+		if _, err := tx.ExecContext(ctx, query, userRole.UserUno, userRole.RoleCode, userRole.Jno); err != nil {
+			return fmt.Errorf("RemoveUserRole fail: %w", err)
+		}
+	}
+	return nil
+}

--- a/csm-api/store/user_valid.go
+++ b/csm-api/store/user_valid.go
@@ -20,7 +20,7 @@ func (r *Repository) GetUserValid(ctx context.Context, db Queryer, userId string
 			T2.ROLE_CODE
 		FROM
 			COMMON.V_BIZ_USER_INFO T1
-			LEFT JOIN IRIS_USER_ROLE_MAP T2 ON T1.UNO = T2.USER_UNO
+			LEFT JOIN IRIS_USER_ROLE_MAP T2 ON T1.UNO = T2.USER_UNO AND T2.JNO = 0
 		WHERE T1.IS_USE = 'Y'
 		AND T1.USER_ID = :1
 		AND t1.USER_PWD = :2`


### PR DESCRIPTION
1. 기존의 협력업체 관리감독자는 안전보건시스템에 있는 직원만 나왔기 때문에 조직도의 CONTRUCTION에 포함되어 있는 직원도 포함 시켜서 조회되도록 수정
2. 사용자 권한을 추가/삭제/조회하는 로직 추가
3. 로그기록용 구조체에 상황에 따라 슬라이스도 사용할 수 있도록 추가