### PR TITLE
에러발생시 에러로그파일 기록

### DIFF
--- a/csm-api/config/config.go
+++ b/csm-api/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Domain     string `env:"DOMAIN" envDefault:"localhost"`
 	UploadPath string `env:"UPLOAD_PATH" envDefault:"uploads"`
 	LogPath    string `env:"LOG_PATH" envDefault:"logs"`
+	ErrLogPath string `env:"ERR_LOG_PATH" envDefault:"logs/error"`
 }
 
 // caarlos0/env 패키지를 사용하여 struct의 envDefault값을 환경변수로 넘겨준다.

--- a/csm-api/config/config_prod.go
+++ b/csm-api/config/config_prod.go
@@ -36,4 +36,9 @@ func init() {
 	if err != nil {
 		log.Fatalf("Failed to set LOG_PATH: %v", err)
 	}
+
+	err = os.Setenv("ERR_LOG_PATH", "/tmp/data/csm/logs/error")
+	if err != nil {
+		log.Fatalf("Failed to set LOG_PATH: %v", err)
+	}
 }

--- a/csm-api/entity/log.go
+++ b/csm-api/entity/log.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"context"
+	"csm-api/auth"
 	"csm-api/config"
 	"encoding/json"
 	"fmt"
@@ -8,9 +10,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 )
 
+// 추가/수정/삭제 정상 기록 로그
 type ItemLogEntry struct {
 	Time     string                   `json:"time"`
 	Type     string                   `json:"type"`
@@ -22,6 +26,38 @@ type ItemLogEntry struct {
 	Items    []map[string]interface{} `json:"items"`
 }
 
+// 에러 메세지 기록 로그
+type ItemErrLogEntry struct {
+	Time       string `json:"time"`
+	UserId     string `json:"user_id"`
+	UserUno    int64  `json:"user_uno"`
+	ErrMessage string `json:"err_message"`
+}
+
+type LoggedError struct {
+	Err error
+}
+
+func (e *LoggedError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *LoggedError) Unwrap() error {
+	return e.Err
+}
+
+// Helper: 이미 로그 찍은 에러로 감싸기
+func MarkAsLogged(err error) error {
+	return &LoggedError{Err: err}
+}
+
+// Helper: 이 에러가 이미 로깅된 것인지 확인
+func IsLoggedError(err error) bool {
+	_, ok := err.(*LoggedError)
+	return ok
+}
+
+// 정상 기록 구조체 파싱
 func DecodeItem[T any](r *http.Request, model T) (*ItemLogEntry, T, error) {
 	var itemLog ItemLogEntry
 	var result T
@@ -104,10 +140,91 @@ func WriteLog(itemLog *ItemLogEntry) {
 		log.Printf("로그 파일 열기 실패 (%s): %v\n", logFilePath, err)
 		return
 	}
-	defer f.Close()
+	defer func(f *os.File) {
+		err = f.Close()
+		if err != nil {
+			log.Printf("로그 파일 닫기 실패: %v\n", err)
+		}
+	}(f)
 
 	if _, err := f.WriteString(string(logJSON) + "\n"); err != nil {
 		log.Printf("로그 쓰기 실패 (%s): %v\n", logFilePath, err)
 		return
 	}
+}
+
+// 에러메세지 에러로그파일에 저장 후 에러 반환
+func WriteErrorLog(ctx context.Context, err error) error {
+	cfg, cfgErr := config.NewConfig()
+	if cfgErr != nil {
+		log.Printf("config.NewConfig() 실패: %v\n", cfgErr)
+		return err // config 실패해도 원래 에러는 그대로 리턴
+	}
+
+	// 현재 시간
+	now := time.Now()
+	year := now.Format("2006")
+	month := now.Format("01")
+	day := now.Format("20060102")
+
+	// 로그 디렉토리 생성: ex) /tmp/data/csm/error/2025/07
+	logDir := filepath.Join(cfg.ErrLogPath, year, month)
+	if mkErr := os.MkdirAll(logDir, os.ModePerm); mkErr != nil {
+		log.Printf("에러 로그 디렉토리 생성 실패 (%s): %v\n", logDir, mkErr)
+		return err
+	}
+
+	// 파일명: csm_error_YYYYMMDD.log
+	logFileName := fmt.Sprintf("csm_error_%s.log", day)
+	logFilePath := filepath.Join(logDir, logFileName)
+
+	// context에서 사용자 정보 추출
+	userId, ok := auth.GetContext(ctx, auth.UserId{})
+	if !ok {
+		userId = "unknown"
+	}
+	unoStr, ok := auth.GetContext(ctx, auth.Uno{})
+	if !ok {
+		unoStr = "0"
+	}
+	userUno, parseErr := strconv.ParseInt(unoStr, 10, 64)
+	if parseErr != nil {
+		userUno = 0
+	}
+
+	// 로그 데이터 생성
+	item := &ItemErrLogEntry{
+		Time:       now.Format("2006-01-02 15:04:05"),
+		UserId:     userId,
+		UserUno:    userUno,
+		ErrMessage: err.Error(),
+	}
+
+	// JSON 직렬화
+	logJSON, marshalErr := json.MarshalIndent(item, "", "\t")
+	if marshalErr != nil {
+		log.Printf("에러 로그 직렬화 실패: %v\n", marshalErr)
+		return err
+	}
+
+	// 파일에 이어쓰기
+	f, openErr := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if openErr != nil {
+		log.Printf("에러 로그 파일 열기 실패 (%s): %v\n", logFilePath, openErr)
+		return err
+	}
+	defer func(f *os.File) {
+		if closeErr := f.Close(); closeErr != nil {
+			log.Printf("에러 로그 파일 닫기 실패: %v\n", closeErr)
+		}
+	}(f)
+
+	if _, writeErr := f.WriteString(string(logJSON) + "\n"); writeErr != nil {
+		log.Printf("에러 로그 쓰기 실패 (%s): %v\n", logFilePath, writeErr)
+		return err
+	}
+
+	log.Printf("userId: %s, userUno: %d, err: %v\n", userId, userUno, err)
+
+	return MarkAsLogged(err)
 }

--- a/csm-api/handler/response.go
+++ b/csm-api/handler/response.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"csm-api/entity"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -68,6 +69,9 @@ func RespondJSON(ctx context.Context, w http.ResponseWriter, body any, status in
 }
 
 func FailResponse(ctx context.Context, w http.ResponseWriter, err error) {
+	//에러 로그 기록
+	_ = entity.WriteErrorLog(ctx, err)
+
 	RespondJSON(
 		ctx,
 		w,

--- a/csm-api/service/service_address_search.go
+++ b/csm-api/service/service_address_search.go
@@ -30,7 +30,6 @@ type ServiceAddressSearch struct {
 func (s *ServiceAddressSearch) GetAPILatitudeLongtitude(roadAddress string) (*entity.Point, error) {
 
 	if roadAddress == "" {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("roadAddress parameter is missing")
 	}
 	// apiUrl주소
@@ -51,7 +50,6 @@ func (s *ServiceAddressSearch) GetAPILatitudeLongtitude(roadAddress string) (*en
 	// api 호출
 	body, err := api.CallGetAPI(apiUrl)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("call GetWhetherSrtNcst API error: %v", err)
 	}
 
@@ -88,12 +86,10 @@ func (s *ServiceAddressSearch) GetAPILatitudeLongtitude(roadAddress string) (*en
 	// api response parse
 	var res AddressSearching
 	if err = json.Unmarshal([]byte(body), &res); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("AddressSearch api JSON parse err: %v", err)
 	}
 
 	if res.Response.Status != "OK" {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("AddressSearch api response err: %s", res.Response.Error.Text)
 
 	} else {
@@ -112,7 +108,6 @@ func (s *ServiceAddressSearch) GetAPILatitudeLongtitude(roadAddress string) (*en
 //   - roadAddress : 도로명 주소
 func (s *ServiceAddressSearch) GetAPISiteMapPoint(roadAddress string) (*entity.MapPoint, error) {
 	if roadAddress == "" {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("roadAddress parameter is missing")
 	}
 	if roadAddress == "undefined" {
@@ -153,19 +148,16 @@ func (s *ServiceAddressSearch) GetAPISiteMapPoint(roadAddress string) (*entity.M
 	// api 호출
 	body, err := api.CallGetAPI(apiUrl)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("call GetWhetherSrtNcst API error: %v", err)
 	}
 
 	// 응답 json으로 변환
 	var res SiteMapPoint
 	if err = json.Unmarshal([]byte(body), &res); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("SiteMapPoint api JSON parse err: %v", err)
 	}
 
 	if res.Response.Status != "OK" {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("SiteMapPoint api response err: %s", res.Response.Error.Text)
 	}
 

--- a/csm-api/service/service_code.go
+++ b/csm-api/service/service_code.go
@@ -16,7 +16,6 @@ type ServiceCode struct {
 func (s *ServiceCode) GetCodeList(ctx context.Context, pCode string) (*entity.Codes, error) {
 	list, err := s.Store.GetCodeList(ctx, s.SafeDB, pCode)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_code/GetCodeList err: %w", err)
 	}
 
@@ -31,14 +30,12 @@ func (s *ServiceCode) GetCodeTree(ctx context.Context, pCode string) (*entity.Co
 	// 코드리스트 조회
 	codes, err := s.Store.GetCodeTree(ctx, s.SafeDB, pCode)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_code/GetCodeSetList err: %w", err)
 	}
 
 	// 트리구조로 반환
 	trees, err := entity.ConvertCodesToCodeTree(*codes, pCode)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_code/ConvertCodesToCodeTree err: %w", err)
 	}
 
@@ -73,7 +70,6 @@ func (s *ServiceCode) MergeCode(ctx context.Context, code entity.Code) (err erro
 	}()
 
 	if err = s.Store.MergeCode(ctx, tx, code); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_code/MergeCode err: %w", err)
 	}
 
@@ -126,12 +122,10 @@ func (s *ServiceCode) ModifySortNo(ctx context.Context, codeSorts entity.CodeSor
 		}
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				//TODO: 에러 아카이브
 				err = fmt.Errorf("service_code/MergeCode err: %v\n; rollback err: %w", err, rollbackErr)
 			}
 		} else {
 			if commitErr := tx.Commit(); commitErr != nil {
-				//TODO: 에러 아카이브
 				err = fmt.Errorf("service_code/MergeCode err: %v\n; commit err: %w", err, commitErr)
 			}
 		}
@@ -139,7 +133,6 @@ func (s *ServiceCode) ModifySortNo(ctx context.Context, codeSorts entity.CodeSor
 
 	for _, codeSort := range codeSorts {
 		if err = s.Store.ModifySortNo(ctx, tx, *codeSort); err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("service_code/ModifySortNo err: %w", err)
 		}
 	}

--- a/csm-api/service/service_device.go
+++ b/csm-api/service/service_device.go
@@ -32,13 +32,11 @@ func (s *ServiceDevice) GetDeviceList(ctx context.Context, page entity.Page, sea
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_device/GetDeviceList err: %w", err)
 	}
 
 	list, err := s.Store.GetDeviceList(ctx, s.SafeDB, pageSql, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_device/GetDeviceList err: %w", err)
 	}
 
@@ -51,7 +49,6 @@ func (s *ServiceDevice) GetDeviceList(ctx context.Context, page entity.Page, sea
 func (s *ServiceDevice) GetDeviceListCount(ctx context.Context, search entity.Device, retry string) (int, error) {
 	count, err := s.Store.GetDeviceListCount(ctx, s.SafeDB, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_device/GetDeviceListCount err: %w", err)
 	}
 
@@ -85,7 +82,6 @@ func (s *ServiceDevice) AddDevice(ctx context.Context, device entity.Device) (er
 	}()
 
 	if err = s.Store.AddDevice(ctx, tx, device); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_device/AddDevice err: %w", err)
 	}
 	return
@@ -97,7 +93,6 @@ func (s *ServiceDevice) AddDevice(ctx context.Context, device entity.Device) (er
 func (s *ServiceDevice) ModifyDevice(ctx context.Context, device entity.Device) (err error) {
 	tx, err := s.SafeTDB.BeginTx(ctx, nil)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_device/ModifyDevice BeginTx fail err: %w", err)
 	}
 
@@ -109,7 +104,6 @@ func (s *ServiceDevice) ModifyDevice(ctx context.Context, device entity.Device) 
 		}
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				//TODO: 에러 아카이브
 				err = fmt.Errorf("service_device/ModifyDevice Rollback err: %w", rollbackErr)
 			}
 		} else {
@@ -120,7 +114,6 @@ func (s *ServiceDevice) ModifyDevice(ctx context.Context, device entity.Device) 
 	}()
 
 	if err = s.Store.ModifyDevice(ctx, tx, device); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_device/UpdateDevice err: %w", err)
 	}
 	return
@@ -160,7 +153,6 @@ func (s *ServiceDevice) RemoveDevice(ctx context.Context, dno int64) (err error)
 	}
 
 	if err = s.Store.RemoveDevice(ctx, tx, dnoSql); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_device/RemoveDevice err: %w", err)
 	}
 	return
@@ -181,7 +173,6 @@ func (s *ServiceDevice) GetCheckRegisteredDevices(ctx context.Context) ([]string
 	// iris_recd_log 테이블의 iris_data값인 json에 들어온 deviceName을 파싱해서 deviceList 얻기
 	for _, device := range *devices {
 		if err = json.Unmarshal([]byte(device.IrisData.String), &log); err != nil {
-			//TODO: 에러 아카이브 처리
 			return nil, fmt.Errorf("GetDeviceList JSON parse err: %v\n", err)
 		}
 
@@ -198,7 +189,6 @@ func (s *ServiceDevice) GetCheckRegisteredDevices(ctx context.Context) ([]string
 	for deviceName, _ := range deviceList {
 		check, err = s.Store.GetCheckRegistered(ctx, s.SafeDB, deviceName)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return nil, fmt.Errorf("service_device/GetCheckRegisteredDevices err: %v\n", err)
 		}
 		if check == 0 {

--- a/csm-api/service/service_equip.go
+++ b/csm-api/service/service_equip.go
@@ -44,7 +44,6 @@ func (s *ServiceEquip) MergeEquipCnt(ctx context.Context, equips entity.EquipTem
 		}
 	}()
 	if err = s.Store.MergeEquipCnt(ctx, tx, equips); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service;MergeEquipCnt failed: %v", err)
 	}
 	return

--- a/csm-api/service/service_notice.go
+++ b/csm-api/service/service_notice.go
@@ -30,7 +30,6 @@ func (s *ServiceNotice) GetNoticeList(ctx context.Context, page entity.Page, sea
 	// 권한 조회
 	list, err := s.UserStore.GetAuthorizationList(ctx, s.SafeDB, "/notice")
 	if err != nil {
-		// TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("service_notice/GetNoticeList GetAuthorizationList err: %w", err)
 	}
 
@@ -46,13 +45,11 @@ func (s *ServiceNotice) GetNoticeList(ctx context.Context, page entity.Page, sea
 	pageSql, err = pageSql.OfPageSql(page)
 
 	if err != nil {
-		//TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("service_notice/GetNoticeList err : %w", err)
 	}
 
 	notices, err := s.Store.GetNoticeList(ctx, s.SafeDB, uno, roleInt, pageSql, search)
 	if err != nil {
-		//TODO: 에러 아카이브 처리
 		return &entity.Notices{}, fmt.Errorf("fail to list notice: %w", err)
 	}
 
@@ -71,7 +68,6 @@ func (s *ServiceNotice) GetNoticeListCount(ctx context.Context, search entity.No
 	// 권한 조회
 	list, err := s.UserStore.GetAuthorizationList(ctx, s.SafeDB, "/notice")
 	if err != nil {
-		// TODO: 에러 아카이브 처리
 		return 0, fmt.Errorf("service_notice/GetNoticeList GetAuthorizationList err: %w", err)
 	}
 
@@ -84,7 +80,6 @@ func (s *ServiceNotice) GetNoticeListCount(ctx context.Context, search entity.No
 
 	count, err := s.Store.GetNoticeListCount(ctx, s.SafeDB, uno, roleInt, search)
 	if err != nil {
-		//TODO: 에러 아카이브 처리
 		return 0, fmt.Errorf("service_notice/GetNoticeListCount err : %w", err)
 	}
 
@@ -118,7 +113,6 @@ func (s *ServiceNotice) AddNotice(ctx context.Context, notice entity.Notice) (er
 		}
 	}()
 	if err = s.Store.AddNotice(ctx, tx, notice); err != nil {
-		//TODO: 에러 아카이브 처리
 		return fmt.Errorf("service_notice/AddNotice err : %w", err)
 	}
 
@@ -152,7 +146,6 @@ func (s *ServiceNotice) ModifyNotice(ctx context.Context, notice entity.Notice) 
 	}()
 
 	if err = s.Store.ModifyNotice(ctx, tx, notice); err != nil {
-		//TODO: 에러 아카이브 처리
 		return fmt.Errorf("service_notice/ModifyNotice err: %w", err)
 	}
 
@@ -186,7 +179,6 @@ func (s *ServiceNotice) RemoveNotice(ctx context.Context, idx null.Int) (err err
 	}()
 
 	if err = s.Store.RemoveNotice(ctx, tx, idx); err != nil {
-		//TODO: 에러 아카이브 처리
 		return fmt.Errorf("service_notice/RemomveNotice err: %w", err)
 	}
 

--- a/csm-api/service/service_organization.go
+++ b/csm-api/service/service_organization.go
@@ -28,13 +28,11 @@ func (s *ServiceOrganization) GetOrganizationClientList(ctx context.Context, jno
 	clientSql := &entity.OrganizationSqls{}
 	clientSql, err := s.Store.GetOrganizationClientList(ctx, s.TimeSheetDB, jnoSql)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/GetOrganizationClientList: %w", err)
 	}
 
 	clients := &entity.Organizations{} //  []organization
 	if err := entity.ConvertSliceToRegular(*clientSql, clients); err != nil {
-		//TODO: 에러 아카이브
 		return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/CovertSliceToRegular: %w", err)
 	}
 
@@ -79,13 +77,11 @@ func (s *ServiceOrganization) GetOrganizationHtencList(ctx context.Context, jno 
 
 	funcNameSqls, err := s.Store.GetFuncNameList(ctx, s.TimeSheetDB)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/GetFuncNameList: %w", err)
 	}
 
 	funcNames := &entity.FuncNames{}
 	if err := entity.ConvertSliceToRegular(*funcNameSqls, funcNames); err != nil {
-		//TODO: 에러 아카이브
 		return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/CovertSliceToRegular: %w", err)
 	}
 
@@ -102,7 +98,6 @@ func (s *ServiceOrganization) GetOrganizationHtencList(ctx context.Context, jno 
 		hitechSql := &entity.OrganizationSqls{}
 		hitechSql, err := s.Store.GetOrganizationHtencList(ctx, s.TimeSheetDB, jnoSql, funcNoSql)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/GetOrganizationHtencList: %w", err)
 		}
 		if len(*hitechSql) == 0 {
@@ -111,7 +106,6 @@ func (s *ServiceOrganization) GetOrganizationHtencList(ctx context.Context, jno 
 
 		hitech := &entity.Organizations{}
 		if err := entity.ConvertSliceToRegular(*hitechSql, hitech); err != nil {
-			//TODO: 에러 아카이브
 			return &entity.OrganizationPartitions{}, fmt.Errorf("ServiceOrganization/ConvertSliceToRegular: %w", err)
 		}
 

--- a/csm-api/service/service_project.go
+++ b/csm-api/service/service_project.go
@@ -26,14 +26,12 @@ type ServiceProject struct {
 func (p *ServiceProject) GetProjectList(ctx context.Context, sno int64, targetDate time.Time) (*entity.ProjectInfos, error) {
 	projectInfos, err := p.Store.GetProjectList(ctx, p.SafeDB, sno, targetDate)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.ProjectInfos{}, fmt.Errorf("service_project/getProjectList error: %w", err)
 	}
 
 	// 안전관리자 수 조회
 	safeInfos, err := p.Store.GetProjectSafeWorkerCountList(ctx, p.SafeDB, targetDate)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_project/getProjectSafeWorkerCountList error: %w", err)
 	}
 
@@ -47,7 +45,6 @@ func (p *ServiceProject) GetProjectList(ctx context.Context, sno int64, targetDa
 			for _, jonPe := range jobPeList {
 				uno, err := strconv.Atoi(jonPe)
 				if err != nil {
-					//TODO: 에러 아카이브
 					return &entity.ProjectInfos{}, fmt.Errorf("service_project/strconv.Atoi(jonPe) parse err")
 				}
 				unoList = append(unoList, uno)
@@ -57,7 +54,6 @@ func (p *ServiceProject) GetProjectList(ctx context.Context, sno int64, targetDa
 		// pe 정보 일괄 조회
 		userPeList, err := p.UserStore.GetUserInfoPeList(ctx, p.SafeDB, unoList)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return &entity.ProjectInfos{}, fmt.Errorf("service_project/GetUserInfoPeList error: %w", err)
 		}
 		projectInfo.ProjectPeList = userPeList
@@ -83,14 +79,12 @@ func (p *ServiceProject) GetProjectWorkerCountList(ctx context.Context, targetDa
 	// 근로자 수 조회
 	projectInfos, err := p.Store.GetProjectWorkerCountList(ctx, p.SafeDB, targetDate)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.ProjectInfos{}, fmt.Errorf("service_project/getProjectWorkerCountList error: %w", err)
 	}
 
 	// 안전관리자 수 조회
 	safeInfos, err := p.Store.GetProjectSafeWorkerCountList(ctx, p.SafeDB, targetDate)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_project/getProjectSafeWorkerCountList error: %w", err)
 	}
 
@@ -115,7 +109,6 @@ func (p *ServiceProject) GetProjectWorkerCountList(ctx context.Context, targetDa
 func (p *ServiceProject) GetProjectNmList(ctx context.Context) (*entity.ProjectInfos, error) {
 	list, err := p.Store.GetProjectNmList(ctx, p.SafeDB)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.ProjectInfos{}, fmt.Errorf("service_project/getProjectNmList error: %w", err)
 	}
 
@@ -129,13 +122,11 @@ func (p *ServiceProject) GetUsedProjectList(ctx context.Context, page entity.Pag
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.JobInfos{}, fmt.Errorf("service_project/OfPageSql error: %w", err)
 	}
 
 	jobInfos, err := p.Store.GetUsedProjectList(ctx, p.SafeDB, pageSql, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.JobInfos{}, fmt.Errorf("service_project/GetUsedProjectList error: %w", err)
 	}
 
@@ -148,7 +139,6 @@ func (p *ServiceProject) GetUsedProjectList(ctx context.Context, page entity.Pag
 func (p *ServiceProject) GetUsedProjectCount(ctx context.Context, search entity.JobInfo, retry string) (int, error) {
 	count, err := p.Store.GetUsedProjectCount(ctx, p.SafeDB, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_project/GetUsedProjectCount error: %w", err)
 	}
 
@@ -162,13 +152,11 @@ func (p *ServiceProject) GetAllProjectList(ctx context.Context, page entity.Page
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.JobInfos{}, fmt.Errorf("service_project/OfPageSql error: %w", err)
 	}
 
 	jobInfos, err := p.Store.GetAllProjectList(ctx, p.SafeDB, pageSql, search, isAll, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.JobInfos{}, fmt.Errorf("service_project/GetUsedProjectList error: %w", err)
 	}
 
@@ -185,7 +173,6 @@ func (p *ServiceProject) GetAllProjectCount(ctx context.Context, search entity.J
 		count += 1
 	}
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_project/GetAllProjectCount error: %w", err)
 	}
 
@@ -207,13 +194,11 @@ func (p *ServiceProject) GetStaffProjectList(ctx context.Context, page entity.Pa
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.JobInfos{}, fmt.Errorf("service_project/OfPageSql error: %w", err)
 	}
 
 	jobInfos, err := p.Store.GetStaffProjectList(ctx, p.SafeDB, pageSql, search, unoSql)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.JobInfos{}, fmt.Errorf("service_project/GetStaffProjectList: %w", err)
 	}
 	return jobInfos, nil
@@ -234,7 +219,6 @@ func (p *ServiceProject) GetStaffProjectCount(ctx context.Context, search entity
 
 	count, err := p.Store.GetStaffProjectCount(ctx, p.SafeDB, search, unoSql)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_project/GetStaffProjectCount error: %w", err)
 	}
 
@@ -262,7 +246,6 @@ func (p *ServiceProject) GetProjectNmUnoList(ctx context.Context, uno int64, rol
 	projectInfos, err := p.Store.GetProjectNmUnoList(ctx, p.SafeDB, unoSql, roleInt)
 
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.ProjectInfos{}, fmt.Errorf("service_project/getProjectNmList error: %w", err)
 	}
 
@@ -276,14 +259,12 @@ func (s *ServiceProject) GetNonUsedProjectList(ctx context.Context, page entity.
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_project/GetNonUsedProjectList ofPageSql error: %w", err)
 	}
 
 	list, err := s.Store.GetNonUsedProjectList(ctx, s.SafeDB, pageSql, search, retry)
 
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_project/GetNonUsedProjectList error: %w", err)
 	}
 
@@ -297,7 +278,6 @@ func (s *ServiceProject) GetNonUsedProjectCount(ctx context.Context, search enti
 	count, err := s.Store.GetNonUsedProjectCount(ctx, s.SafeDB, search, retry)
 
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_project/GetNonUsedProjectCount error: %w", err)
 	}
 
@@ -341,7 +321,6 @@ func (s *ServiceProject) AddProject(ctx context.Context, project entity.ReqProje
 
 	err = s.Store.AddProject(ctx, tx, project)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_project/AddProject error: %w", err)
 	}
 	return
@@ -375,7 +354,6 @@ func (s *ServiceProject) ModifyDefaultProject(ctx context.Context, project entit
 
 	err = s.Store.ModifyDefaultProject(ctx, tx, project)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_project/ModifyDefaultProject error: %w", err)
 	}
 	return
@@ -409,7 +387,6 @@ func (s *ServiceProject) ModifyUseProject(ctx context.Context, project entity.Re
 
 	err = s.Store.ModifyUseProject(ctx, tx, project)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_project/ModifyUseProject error: %w", err)
 	}
 	return
@@ -443,7 +420,6 @@ func (s *ServiceProject) RemoveProject(ctx context.Context, sno int64, jno int64
 
 	err = s.Store.RemoveProject(ctx, tx, sno, jno)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_project/RemoveProject error: %w", err)
 	}
 	return

--- a/csm-api/service/service_project_setting.go
+++ b/csm-api/service/service_project_setting.go
@@ -24,7 +24,6 @@ func (s *ServiceProjectSetting) GetManHourList(ctx context.Context, jno int64) (
 
 	manhours, err := s.Store.GetManHourList(ctx, s.SafeDB, jno)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.ManHours{}, fmt.Errorf("service_manHour/GetManHourList err: %w", err)
 	}
 
@@ -45,12 +44,10 @@ func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *ent
 		}
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				// TODO: 에러 아카이브
 				err = fmt.Errorf("service_project_setting/MergeProjectSetting Rollback error: %w", rollbackErr)
 			}
 		} else {
 			if commitErr := tx.Commit(); commitErr != nil {
-				// TODO: 에러 아카이브
 				err = fmt.Errorf("service_project_setting/MergeProjectSetting Commit error: %w", commitErr)
 			}
 		}
@@ -62,7 +59,6 @@ func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *ent
 	// jno에 해당하는 공수 찾기
 	deleteManhours, err := s.Store.GetManHourList(ctx, s.SafeDB, jno)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("MergeManHours/GetManHourList err: %w", err)
 	}
 
@@ -78,7 +74,6 @@ func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *ent
 
 			// 삭제
 			if err = s.DeleteManHour(ctx, deleteManhour.Mhno.Int64, *deleteManhour); err != nil {
-				// TODO: 에러 아카이브
 				return fmt.Errorf("MergeManHours err: %w", err)
 			}
 		}
@@ -93,13 +88,11 @@ func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *ent
 		// 추가
 		err = s.Store.AddManHour(ctx, tx, *manHour)
 		if err != nil {
-			// TODO: 에러 아카이브
 			return fmt.Errorf("service_project_setting/AddManHour error: %w", err)
 		}
 
 		// 로그 남기기
 		if err = s.Store.ManHourLog(ctx, tx, *manHour); err != nil {
-			// TODO: 에러 아카이브
 			return fmt.Errorf("service_project_setting/MergeManHour error: %w", err)
 		}
 	}
@@ -111,7 +104,6 @@ func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *ent
 
 	// 공수에 맞춰 근로자 업데이트
 	if err = s.WorkHourStore.ModifyWorkHourByJno(ctx, tx, jno, user, nil); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/WorkHourStore/: %w", err)
 	}
 
@@ -124,7 +116,6 @@ func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *ent
 func (s *ServiceProjectSetting) MergeProjectSetting(ctx context.Context, project entity.ProjectSetting) (err error) {
 	tx, err := s.SafeTDB.BeginTx(ctx, nil)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/ModifyProjectSetting BeginTx error: %w", err)
 	}
 
@@ -136,12 +127,10 @@ func (s *ServiceProjectSetting) MergeProjectSetting(ctx context.Context, project
 		}
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				// TODO: 에러 아카이브
 				err = fmt.Errorf("service_project_setting/ModifyProjectSetting Rollback error: %w", rollbackErr)
 			}
 		} else {
 			if commitErr := tx.Commit(); commitErr != nil {
-				// TODO: 에러 아카이브
 				err = fmt.Errorf("service_project_setting/ModifyProjectSetting Commit error: %w", commitErr)
 			}
 		}
@@ -153,7 +142,6 @@ func (s *ServiceProjectSetting) MergeProjectSetting(ctx context.Context, project
 
 	count, err := s.Store.MergeProjectSetting(ctx, tx, project)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/ModifyProjectSetting error: %w", err)
 	}
 
@@ -164,13 +152,11 @@ func (s *ServiceProjectSetting) MergeProjectSetting(ctx context.Context, project
 		jno := project.Jno.Int64
 		user := project.Base
 		if err = s.WorkHourStore.ModifyWorkHourByJno(ctx, tx, jno, user, nil); err != nil {
-			// TODO: 에러 아카이브
 			return fmt.Errorf("service_project_setting/WorkHourStore error: %w", err)
 		}
 	}
 
 	if err = s.Store.ProjectSettingLog(ctx, tx, project); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/MergeManHour error: %w", err)
 	}
 
@@ -184,7 +170,6 @@ func (s *ServiceProjectSetting) CheckProjectSetting(ctx context.Context) (count 
 
 	projects := &entity.ProjectSettings{}
 	if projects, err = s.Store.GetCheckProjectSetting(ctx, s.SafeDB); err != nil {
-		// TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_project_setting/CheckProjectSetting error: %w", err)
 	}
 
@@ -201,7 +186,6 @@ func (s *ServiceProjectSetting) CheckProjectSetting(ctx context.Context) (count 
 		manHours := entity.ManHours{manHourMore, manHourLess}
 
 		if err = s.MergeManHours(ctx, &manHours); err != nil {
-			// TODO: 에러 아카이브
 			return 0, fmt.Errorf("service_manhours/MergeManHours error: %w", err)
 		}
 
@@ -216,7 +200,6 @@ func (s *ServiceProjectSetting) CheckProjectSetting(ctx context.Context) (count 
 		setting.CancelCode = utils.ParseNullString("NO_DAY")
 
 		if err = s.MergeProjectSetting(ctx, *setting); err != nil {
-			// TODO: 에러 아카이브
 			return 0, fmt.Errorf("service_project_setting/CheckProjectSetting error: %w", err)
 		}
 
@@ -233,13 +216,11 @@ func (s *ServiceProjectSetting) GetProjectSetting(ctx context.Context, jno int64
 
 	setting, err := s.Store.GetProjectSetting(ctx, s.SafeDB, jno)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.ProjectSettings{}, fmt.Errorf("service_project_setting/GetProjectSetting: %w", err)
 	}
 
 	manHours, err := s.GetManHourList(ctx, jno)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return &entity.ProjectSettings{}, fmt.Errorf("service_project_setting/GetProjectSetting: %w", err)
 	}
 
@@ -257,7 +238,6 @@ func (s *ServiceProjectSetting) GetProjectSetting(ctx context.Context, jno int64
 func (s *ServiceProjectSetting) DeleteManHour(ctx context.Context, mhno int64, manhour entity.ManHour) error {
 	tx, err := s.SafeTDB.BeginTx(ctx, nil)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/ModifyProjectSetting BeginTx error: %w", err)
 	}
 
@@ -269,12 +249,10 @@ func (s *ServiceProjectSetting) DeleteManHour(ctx context.Context, mhno int64, m
 		}
 		if err != nil {
 			if rollbackErr := tx.Rollback(); rollbackErr != nil {
-				// TODO: 에러 아카이브
 				err = fmt.Errorf("service_project_setting/ModifyProjectSetting Rollback error: %w", rollbackErr)
 			}
 		} else {
 			if commitErr := tx.Commit(); commitErr != nil {
-				// TODO: 에러 아카이브
 				err = fmt.Errorf("service_project_setting/ModifyProjectSetting Commit error: %w", commitErr)
 			}
 		}
@@ -282,7 +260,6 @@ func (s *ServiceProjectSetting) DeleteManHour(ctx context.Context, mhno int64, m
 
 	// 공수 삭제
 	if err = s.Store.DeleteManHour(ctx, tx, mhno); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/DeleteManHour error: %w", err)
 	}
 
@@ -290,13 +267,11 @@ func (s *ServiceProjectSetting) DeleteManHour(ctx context.Context, mhno int64, m
 	jno := manhour.Jno.Int64
 	user := manhour.Base
 	if err = s.WorkHourStore.ModifyWorkHourByJno(ctx, tx, jno, user, nil); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/WorkHourStore error: %w", err)
 	}
 
 	// 로그 기록
 	if err = s.Store.ManHourLog(ctx, tx, manhour); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_project_setting/MergeManHour error: %w", err)
 	}
 	return nil

--- a/csm-api/service/service_rest_date.go
+++ b/csm-api/service/service_rest_date.go
@@ -24,7 +24,6 @@ func (s *ServiceRestDate) GetRestDelDates(year string, month string) (entity.Res
 
 	body, err := api.CallGetAPI(url)
 	if err != nil {
-		//TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("call GetRestDelDates API error: %v", err)
 	}
 
@@ -38,7 +37,6 @@ func (s *ServiceRestDate) GetRestDelDates(year string, month string) (entity.Res
 
 	var res RestDelInfo
 	if err = json.Unmarshal([]byte(body), &res); err != nil {
-		//TODO: 에러 아카이브 처리
 		fmt.Println("Unmarshal err or non RestDel Info")
 		return entity.RestDates{}, nil
 	}

--- a/csm-api/service/service_site.go
+++ b/csm-api/service/service_site.go
@@ -58,14 +58,12 @@ func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*e
 
 	uno, err := strconv.ParseInt(unoString, 10, 64)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_site/GetSiteList parseInt err: %w", err)
 	}
 
 	//현장관리 테이블 조회
 	sites, err := s.Store.GetSiteList(ctx, s.SafeDB, targetDate, roleInt, uno)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.Sites{}, fmt.Errorf("service_site/GetSiteList err: %w", err)
 	}
 
@@ -77,7 +75,6 @@ func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*e
 		// 프로젝트 리스트 조회
 		projectInfos, err := s.ProjectService.GetProjectList(ctx, sno, targetDate)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return &entity.Sites{}, fmt.Errorf("service_site/GetProjectList err: %w", err)
 		}
 		site.ProjectList = projectInfos
@@ -91,7 +88,6 @@ func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*e
 				// 작업내용
 				projectDailyList, err := s.ProjectDailyStore.GetProjectDailyContentList(ctx, s.SafeDB, projectInfo.Jno.Int64, targetDate)
 				if err != nil {
-					//TODO: 에러 아카이브
 					return &entity.Sites{}, fmt.Errorf("service_site/GetProjectDailyContentList err: %w", err)
 				}
 				projectInfo.DailyContentList = projectDailyList
@@ -104,7 +100,6 @@ func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*e
 		// 현장 위치 조회
 		sitePos, err := s.SitePosStore.GetSitePosData(ctx, s.SafeDB, sno)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return &entity.Sites{}, fmt.Errorf("service_site/GetSitePosData err: %w", err)
 		}
 		if sitePos.RoadAddress.String == "" {
@@ -127,7 +122,6 @@ func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*e
 		//
 		//siteWeather, err := s.WeatherApiService.GetWeatherSrtNcst(baseDate, baseTime, nx, ny)
 		//if err != nil {
-		//	//TODO: 에러 아카이브
 		//	return &entity.Sites{}, fmt.Errorf("service_site/GetWeatherSrt err: %w", err)
 		//}
 		//site.Weather = siteWeather
@@ -135,7 +129,6 @@ func (s *ServiceSite) GetSiteList(ctx context.Context, targetDate time.Time) (*e
 		// 현장 날짜 조회
 		siteDateData, err := s.SiteDateStore.GetSiteDateData(ctx, s.SafeDB, sno)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return &entity.Sites{}, fmt.Errorf("service_site/GetSiteDateData err: %w", err)
 		}
 		site.SiteDate = siteDateData
@@ -151,13 +144,11 @@ func (s *ServiceSite) GetSiteNmList(ctx context.Context, page entity.Page, searc
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_site/GetSiteNmList OfPageSql err : %w", err)
 	}
 
 	sites, err := s.Store.GetSiteNmList(ctx, s.SafeDB, pageSql, search, nonSite)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.Sites{}, fmt.Errorf("service_site/GetSiteNmList err: %w", err)
 	}
 
@@ -171,7 +162,6 @@ func (s *ServiceSite) GetSiteNmCount(ctx context.Context, search entity.Site, no
 
 	count, err := s.Store.GetSiteNmCount(ctx, s.SafeDB, search, nonSite)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_site/GetSiteNmList err: %w", err)
 	}
 
@@ -184,7 +174,6 @@ func (s *ServiceSite) GetSiteNmCount(ctx context.Context, search entity.Site, no
 func (s *ServiceSite) GetSiteStatsList(ctx context.Context, targetDate time.Time) (*entity.Sites, error) {
 	sites, err := s.Store.GetSiteStatsList(ctx, s.SafeDB, targetDate)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return &entity.Sites{}, fmt.Errorf("service_site/GetSiteStatsList err: %w", err)
 	}
 
@@ -218,12 +207,10 @@ func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) (err err
 	}()
 
 	if site.Sno.Int64 == 0 {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("sno parameter is missing")
 	}
 	// 비고 정보 수정
 	if err = s.Store.ModifySite(ctx, tx, site); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_site/ModifySite err: %w", err)
 	}
 
@@ -237,7 +224,6 @@ func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) (err err
 		},
 	}
 	if err = s.ProjectStore.ModifyDefaultProject(ctx, tx, project); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_site/ModifyDefaultProject err: %w", err)
 	}
 
@@ -260,7 +246,6 @@ func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) (err err
 	if site.SiteDate != nil {
 		siteDate := *site.SiteDate
 		if err = s.SiteDateStore.ModifySiteDate(ctx, tx, site.Sno.Int64, siteDate); err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("service_site/ModifySiteDate err: %v\n", err)
 		}
 	}
@@ -270,7 +255,6 @@ func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) (err err
 		sitePos := *site.SitePos
 		point, err := s.AddressSearchAPIService.GetAPILatitudeLongtitude(site.SitePos.RoadAddress.String)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("service_site/GetApiLatitudeLongtitude err: %w", err)
 		}
 		if point.Latitude != 0.0 {
@@ -283,7 +267,6 @@ func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) (err err
 		}
 
 		if err = s.SitePosStore.ModifySitePosData(ctx, tx, site.Sno.Int64, sitePos); err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("service_site/ModifySitePos err: %v\n", err)
 		}
 	}
@@ -320,7 +303,6 @@ func (s *ServiceSite) AddSite(ctx context.Context, jno int64, user entity.User) 
 
 	err = s.Store.AddSite(ctx, s.SafeDB, tx, jno, user)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_site/AddSite err: %w", err)
 	}
 

--- a/csm-api/service/service_site_date.go
+++ b/csm-api/service/service_site_date.go
@@ -19,7 +19,6 @@ type ServiceSiteDate struct {
 func (s *ServiceSiteDate) GetSiteDateData(ctx context.Context, sno int64) (*entity.SiteDate, error) {
 	siteDate, err := s.Store.GetSiteDateData(ctx, s.DB, sno)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_site_date/GetSiteDateData err: %w", err)
 	}
 
@@ -55,7 +54,6 @@ func (s *ServiceSiteDate) ModifySiteDate(ctx context.Context, sno int64, siteDat
 	}()
 
 	if err := s.Store.ModifySiteDate(ctx, tx, sno, siteDate); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_site_date/ModifySiteDate err: %w", err)
 	}
 

--- a/csm-api/service/service_site_pos.go
+++ b/csm-api/service/service_site_pos.go
@@ -29,7 +29,6 @@ func (s *ServiceSitePos) GetSitePosList(ctx context.Context) ([]entity.SitePos, 
 func (s *ServiceSitePos) GetSitePosData(ctx context.Context, sno int64) (*entity.SitePos, error) {
 	sitePos, err := s.Store.GetSitePosData(ctx, s.DB, sno)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_site_pos/GetSitePosData err: %w", err)
 	}
 
@@ -78,7 +77,6 @@ func (s *ServiceSitePos) ModifySitePos(ctx context.Context, sno int64, sitePos e
 	}()
 
 	if err := s.Store.ModifySitePosData(ctx, tx, sno, sitePos); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_site_pos/ModifySitePosData err: %w", err)
 	}
 

--- a/csm-api/service/service_user.go
+++ b/csm-api/service/service_user.go
@@ -19,7 +19,6 @@ type ServiceUser struct {
 func (u *ServiceUser) GetUserInfoPeList(ctx context.Context, unoList []int) (*entity.UserPeInfos, error) {
 	userPeInfos, err := u.Store.GetUserInfoPeList(ctx, u.SafeDB, unoList)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_user/GetUserInfoPeList err: %w", err)
 	}
 
@@ -53,7 +52,6 @@ func (u *ServiceUser) GetAuthorizationList(ctx context.Context, api string) (*en
 
 	list, err := u.Store.GetAuthorizationList(ctx, u.SafeDB, api)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_user/GetAuthorizationList err: %w", err)
 	}
 

--- a/csm-api/service/service_weather.go
+++ b/csm-api/service/service_weather.go
@@ -49,7 +49,6 @@ func (s *ServiceWeather) GetWeatherSrtNcst(date string, time string, nx int, ny 
 	// api call
 	body, err := api.CallGetAPI(url)
 	if err != nil {
-		//TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("call GetWeatherSrtNcst API error: %v", err)
 	}
 
@@ -65,7 +64,6 @@ func (s *ServiceWeather) GetWeatherSrtNcst(date string, time string, nx int, ny 
 	// response parse
 	var res Weather
 	if err := json.Unmarshal([]byte(body), &res); err != nil {
-		//TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("WeatherSrt api JSON parse err: %v", err)
 	}
 
@@ -115,7 +113,6 @@ func (s *ServiceWeather) GetWeatherWrnMsg() (entity.WeatherWrnMsgList, error) {
 	// api call
 	body, err := api.CallGetAPI(url)
 	if err != nil {
-		//TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("call GetWeatherWrnMsgList API error: %v", err)
 	}
 
@@ -141,12 +138,10 @@ func (s *ServiceWeather) GetWeatherWrnMsg() (entity.WeatherWrnMsgList, error) {
 	// response parse
 	var res Weather
 	if err := json.Unmarshal([]byte(body), &res); err != nil {
-		//TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("WeatherWrnMsg api JSON parse err: %v", err)
 	}
 
 	if res.Response.Header.ResultCode != "00" {
-		//TODO: 에러 아카이브 처리
 		return nil, fmt.Errorf("WeatherWrnMsg api response err : %s", res.Response.Header.ResultMsg)
 	}
 
@@ -274,7 +269,6 @@ func (s *ServiceWeather) SaveWeather(ctx context.Context) (err error) {
 		// 초단기예보 조회
 		res, weatherErr := s.GetWeatherSrtNcst(baseDate, baseTime, nx, ny)
 		if weatherErr != nil {
-			// TODO: 에러 아카이브
 			err = fmt.Errorf("service_weather/Fail GetWeatherSrtNcst: %w", weatherErr)
 		}
 
@@ -282,7 +276,6 @@ func (s *ServiceWeather) SaveWeather(ctx context.Context) (err error) {
 		weather, convertErr := s.convertWeather(res)
 
 		if convertErr != nil {
-			// TODO: 에러 아카이브
 			err = fmt.Errorf("service_weather/ConvertError: %w", convertErr)
 		}
 
@@ -296,7 +289,6 @@ func (s *ServiceWeather) SaveWeather(ctx context.Context) (err error) {
 
 		// weather 저장
 		if err = s.Store.SaveWeather(ctx, tx, *weather); err != nil {
-			// TODO: 에러 아카이브
 			err = fmt.Errorf("service_weather/SaveWeather err: %w", err)
 		}
 	}

--- a/csm-api/service/service_work_hour.go
+++ b/csm-api/service/service_work_hour.go
@@ -39,7 +39,6 @@ func (s *ServiceWorkHour) ModifyWorkHourByJno(ctx context.Context, jno int64, us
 
 	err = s.Store.ModifyWorkHourByJno(ctx, tx, jno, user, ids)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_work_hour.ModifyWorkHourByJno err: %v", err)
 	}
 	return
@@ -71,7 +70,6 @@ func (s *ServiceWorkHour) ModifyWorkHour(ctx context.Context, user entity.Base) 
 
 	err = s.Store.ModifyWorkHour(ctx, tx, user)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_work_hour.ModifyWorkHour err: %v", err)
 	}
 	return

--- a/csm-api/service/service_worker.go
+++ b/csm-api/service/service_worker.go
@@ -32,14 +32,12 @@ func (s *ServiceWorker) GetWorkerTotalList(ctx context.Context, page entity.Page
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_worker;total/OfPageSql err: %v", err)
 	}
 
 	// 조회
 	list, err := s.Store.GetWorkerTotalList(ctx, s.SafeDB, pageSql, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_worker/GetWorkerTotalList err: %v", err)
 	}
 
@@ -53,7 +51,6 @@ func (s *ServiceWorker) GetWorkerTotalList(ctx context.Context, page entity.Page
 func (s *ServiceWorker) GetWorkerTotalCount(ctx context.Context, search entity.Worker, retry string) (int, error) {
 	count, err := s.Store.GetWorkerTotalCount(ctx, s.SafeDB, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_worker/GetWorkerTotalCount err: %v", err)
 	}
 	return count, nil
@@ -67,14 +64,12 @@ func (s *ServiceWorker) GetAbsentWorkerList(ctx context.Context, page entity.Pag
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_worker;ByUserId/OfPageSql err: %v", err)
 	}
 
 	// 조회
 	list, err := s.Store.GetAbsentWorkerList(ctx, s.SafeDB, pageSql, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_worker/GetAbsentWorkerList err: %v", err)
 	}
 
@@ -87,7 +82,6 @@ func (s *ServiceWorker) GetAbsentWorkerList(ctx context.Context, page entity.Pag
 func (s *ServiceWorker) GetAbsentWorkerCount(ctx context.Context, search entity.WorkerDaily, retry string) (int, error) {
 	count, err := s.Store.GetAbsentWorkerCount(ctx, s.SafeDB, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_worker;ByUserId/GetAbsentWorkerCount err: %v", err)
 	}
 	return count, nil
@@ -130,7 +124,6 @@ func (s *ServiceWorker) AddWorker(ctx context.Context, worker entity.Worker) (er
 
 	err = s.Store.AddWorker(ctx, tx, worker)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_worker/AddWorker err: %v", err)
 	}
 	return
@@ -164,7 +157,6 @@ func (s *ServiceWorker) ModifyWorker(ctx context.Context, worker entity.Worker) 
 
 	err = s.Store.ModifyWorker(ctx, tx, worker)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_worker/ModifyWorker err: %v", err)
 	}
 	return
@@ -179,14 +171,12 @@ func (s *ServiceWorker) GetWorkerSiteBaseList(ctx context.Context, page entity.P
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_worker;site_base/OfPageSql err: %v", err)
 	}
 
 	// 조회
 	list, err := s.Store.GetWorkerSiteBaseList(ctx, s.SafeDB, pageSql, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("service_worker/GetWorkerSiteBaseList err: %v", err)
 	}
 
@@ -199,7 +189,6 @@ func (s *ServiceWorker) GetWorkerSiteBaseList(ctx context.Context, page entity.P
 func (s *ServiceWorker) GetWorkerSiteBaseCount(ctx context.Context, search entity.WorkerDaily, retry string) (int, error) {
 	count, err := s.Store.GetWorkerSiteBaseCount(ctx, s.SafeDB, search, retry)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_worker/GetWorkerSiteBaseCount err: %v", err)
 	}
 	return count, nil
@@ -233,7 +222,6 @@ func (s *ServiceWorker) MergeSiteBaseWorker(ctx context.Context, workers entity.
 
 	// 추가/수정
 	if err = s.Store.MergeSiteBaseWorker(ctx, tx, workers); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_worker/MergeSiteBaseWorker err: %v", err)
 	}
 
@@ -273,7 +261,6 @@ func (s *ServiceWorker) ModifyWorkerDeadline(ctx context.Context, workers entity
 
 	// 마감처리
 	if err = s.Store.ModifyWorkerDeadline(ctx, tx, workers); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_worker/ModifyWorkerDeadline err: %v", err)
 	}
 
@@ -320,7 +307,6 @@ func (s *ServiceWorker) ModifyWorkerProject(ctx context.Context, workers entity.
 
 	// 현장 근로자 프로젝트 변경
 	if err = s.Store.ModifyWorkerProject(ctx, tx, workers); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("service_worker/ModifyWorkerProject err: %v", err)
 	}
 
@@ -370,7 +356,6 @@ func (s *ServiceWorker) ModifyWorkerDeadlineInit(ctx context.Context) (err error
 func (s *ServiceWorker) ModifyWorkerOverTime(ctx context.Context) (count int, err error) {
 	tx, err := s.SafeTDB.BeginTx(ctx, nil)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_worker;ModifyWorkerOverTime err: %v", err)
 	}
 
@@ -378,8 +363,6 @@ func (s *ServiceWorker) ModifyWorkerOverTime(ctx context.Context) (count int, er
 	workerOverTimes := &entity.WorkerOverTimes{}
 	workerOverTimes, err = s.Store.GetWorkerOverTime(ctx, s.SafeDB)
 	if err != nil {
-
-		// TODO: 에러 아카이브
 		return 0, fmt.Errorf("service_worker;GetWorkerOverTime err: %v", err)
 	}
 	count = len(*workerOverTimes)
@@ -405,13 +388,11 @@ func (s *ServiceWorker) ModifyWorkerOverTime(ctx context.Context) (count int, er
 
 		// 철야 근로자 철야 표시 및 퇴근시간 합치기.
 		if err = s.Store.ModifyWorkerOverTime(ctx, tx, *workerOverTime); err != nil {
-			// TODO: 에러 아카이브
 			return 0, fmt.Errorf("service_worker/ModifyWorkerOverTime err: %v", err)
 		}
 
 		// 다음날 퇴근 표시 삭제
 		if err = s.Store.DeleteWorkerOverTime(ctx, tx, (*workerOverTime).AfterCno); err != nil {
-			// TODO: 에러 아카이브
 			return 0, fmt.Errorf("service_worker;DeleteWorkerOverTime err: %v", err)
 		}
 	}
@@ -422,7 +403,6 @@ func (s *ServiceWorker) ModifyWorkerOverTime(ctx context.Context) (count int, er
 func (s *ServiceWorker) RemoveSiteBaseWorkers(ctx context.Context, workers entity.WorkerDailys) (err error) {
 	tx, err := s.SafeTDB.BeginTx(ctx, nil)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_worker.RemoveSiteBaseWorkers BeginTx err: %v", err)
 	}
 
@@ -460,7 +440,6 @@ func (s *ServiceWorker) RemoveSiteBaseWorkers(ctx context.Context, workers entit
 func (s *ServiceWorker) ModifyDeadlineCancel(ctx context.Context, workers entity.WorkerDailys) (err error) {
 	tx, err := s.SafeTDB.BeginTx(ctx, nil)
 	if err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("service_worker.ModifyDeadlineCancel BeginTx err: %v", err)
 	}
 

--- a/csm-api/store/store_code.go
+++ b/csm-api/store/store_code.go
@@ -21,7 +21,6 @@ func (r *Repository) GetCodeList(ctx context.Context, db Queryer, pCode string) 
 			  ORDER BY t1."ORDER"`
 
 	if err := db.SelectContext(ctx, &list, query, pCode); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetCodeList err: %w", err)
 	}
 
@@ -31,7 +30,7 @@ func (r *Repository) GetCodeList(ctx context.Context, db Queryer, pCode string) 
 // 코드트리 조회
 func (r *Repository) GetCodeTree(ctx context.Context, db Queryer, pCode string) (*entity.Codes, error) {
 	codes := entity.Codes{}
-	
+
 	query := fmt.Sprintf(`
 			SELECT 
 			    LEVEL, 
@@ -56,7 +55,6 @@ func (r *Repository) GetCodeTree(ctx context.Context, db Queryer, pCode string) 
 		`, pCode)
 
 	if err := db.SelectContext(ctx, &codes, query); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetCodeTrees err: %w", err)
 	}
 
@@ -134,7 +132,6 @@ func (r *Repository) MergeCode(ctx context.Context, tx Execer, code entity.Code)
 		code.UdfVal03, code.UdfVal04, code.UdfVal05, code.UdfVal06, code.UdfVal07,
 		code.SortNo, code.IsUse, code.Etc, code.RegUno, code.RegUser); err != nil {
 
-		//TODO: 에러 아카이브
 		return fmt.Errorf("MergeCode err: %w", err)
 	}
 

--- a/csm-api/store/store_device.go
+++ b/csm-api/store/store_device.go
@@ -104,7 +104,6 @@ func (r *Repository) GetDeviceList(ctx context.Context, db Queryer, page entity.
 				WHERE RNUM > :2`, condition, retryCondition, order)
 
 	if err := db.SelectContext(ctx, &list, query, page.EndNum, page.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetDeviceList err: %v", err)
 	}
 
@@ -177,7 +176,6 @@ func (r *Repository) GetDeviceListCount(ctx context.Context, db Queryer, search 
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetDeviceListCount fail: %w", err)
 	}
 	return count, nil
@@ -212,7 +210,6 @@ func (r *Repository) AddDevice(ctx context.Context, tx Execer, device entity.Dev
 				    :7    
 				)`
 	if _, err := tx.ExecContext(ctx, query, device.Sno, device.DeviceSn, device.DeviceNm, device.Etc, device.IsUse, agent, device.RegUser); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("AddDevice err: %v", err)
 	}
 
@@ -239,7 +236,6 @@ func (r *Repository) ModifyDevice(ctx context.Context, tx Execer, device entity.
 				WHERE DNO = :8`
 
 	if _, err := tx.ExecContext(ctx, query, device.Sno, device.DeviceSn, device.DeviceNm, device.Etc, device.IsUse, device.ModUser, agent, device.Dno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyDevice fail: %v", err)
 	}
 	return nil
@@ -252,7 +248,6 @@ func (r *Repository) RemoveDevice(ctx context.Context, tx Execer, dno sql.NullIn
 	query := `DELETE FROM IRIS_DEVICE_SET WHERE DNO = :1`
 
 	if _, err := tx.ExecContext(ctx, query, dno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("RemoveDevice fail: %v", err)
 	}
 
@@ -268,7 +263,6 @@ func (r *Repository) GetDeviceLog(ctx context.Context, db Queryer) (*entity.Recd
 		SELECT IRIS_DATA FROM IRIS_RECD_LOG WHERE to_date(REG_DATE) = TRUNC(SYSDATE) `
 
 	if err := db.SelectContext(ctx, &recodes, query); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetDeviceLog fail: %v", err)
 	}
 
@@ -291,7 +285,6 @@ func (r *Repository) GetCheckRegistered(ctx context.Context, db Queryer, deviceN
 			`
 
 	if err := db.GetContext(ctx, &count, query, deviceName); err != nil {
-		//TODO: 에러 아카이브
 		return -1, fmt.Errorf("GetDeviceListCount fail: %v", err)
 	}
 

--- a/csm-api/store/store_equip.go
+++ b/csm-api/store/store_equip.go
@@ -50,7 +50,6 @@ func (r *Repository) MergeEquipCnt(ctx context.Context, tx Execer, equips entity
 
 	for _, equip := range equips {
 		if _, err := tx.ExecContext(ctx, query, equip.Sno, equip.Jno, equip.Cnt); err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("MergeEquipCnt ExecContext fail: %v", err)
 		}
 	}

--- a/csm-api/store/store_notice.go
+++ b/csm-api/store/store_notice.go
@@ -109,7 +109,6 @@ func (r *Repository) GetNoticeList(ctx context.Context, db Queryer, uno null.Int
 		condition, order)
 
 	if err := db.SelectContext(ctx, &notices, query, role, uno, page.EndNum, page.StartNum); err != nil {
-		//TODO: 에러 아카이브 처리
 		fmt.Errorf("store/notice. NoticeList error %s", err)
 		return nil, err
 	}
@@ -167,7 +166,6 @@ func (r *Repository) GetNoticeListCount(ctx context.Context, db Queryer, uno nul
 				%s`, condition)
 
 	if err := db.GetContext(ctx, &count, query, role, uno); err != nil {
-		//TODO: 에러 아카이브 처리
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}

--- a/csm-api/store/store_organization.go
+++ b/csm-api/store/store_organization.go
@@ -41,7 +41,6 @@ func (r *Repository) GetOrganizationClientList(ctx context.Context, db Queryer, 
 				ORDER BY JM.FUNC_NAME ASC, SC.VAL5 ASC, JM.SORT_NO ASC`)
 
 	if err := db.SelectContext(ctx, &sqlData, query, jno); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetOrganizationClientList err: %w", err)
 	}
 
@@ -116,7 +115,6 @@ func (r *Repository) GetOrganizationHtencList(ctx context.Context, db Queryer, j
 					`)
 
 	if err := db.SelectContext(ctx, &sqlData, query, jno, funcNo); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetOrganizationHtencList err: %w", err)
 	}
 	return &sqlData, nil
@@ -140,7 +138,6 @@ func (r *Repository) GetFuncNameList(ctx context.Context, db Queryer) (*entity.F
 	`)
 
 	if err := db.SelectContext(ctx, &sqlData, query); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetFuncNameList err: %w", err)
 	}
 

--- a/csm-api/store/store_project.go
+++ b/csm-api/store/store_project.go
@@ -142,7 +142,6 @@ func (r *Repository) GetProjectList(ctx context.Context, db Queryer, sno int64, 
 			AND (:7 IS NULL OR t1.SNO = :8)
 			ORDER BY IS_DEFAULT DESC`
 	if err := db.SelectContext(ctx, &projectInfos, sql, snoParam, snoParam, targetDate, targetDate, targetDate, targetDate, snoParam, snoParam); err != nil {
-		//TODO: 에러 아카이브
 		return &projectInfos, fmt.Errorf("getProjectList fail: %v", err)
 	}
 
@@ -228,7 +227,6 @@ func (r *Repository) GetProjectWorkerCountList(ctx context.Context, db Queryer, 
 				WHERE t1.SNO > 100`
 
 	if err := db.SelectContext(ctx, &list, query, targetDate, targetDate, targetDate, targetDate); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetProjectWorkerCountList err: %v", err)
 	}
 
@@ -290,7 +288,6 @@ func (r *Repository) GetProjectSafeWorkerCountList(ctx context.Context, db Query
 				LEFT JOIN cnt t2 ON t1.SNO = t2.SNO AND t1.JNO = t2.JNO`
 
 	if err := db.SelectContext(ctx, &list, query, targetDate); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetProjectSafeWorkerCountList err: %v", err)
 	}
 
@@ -318,7 +315,6 @@ func (r *Repository) GetProjectNmList(ctx context.Context, db Queryer) (*entity.
 			ORDER BY
 				t1.IS_DEFAULT DESC`
 	if err := db.SelectContext(ctx, &projectInfos, sql); err != nil {
-		//TODO: 에러 아카이브
 		return &projectInfos, fmt.Errorf("GetProjectNmList fail: %v", err)
 	}
 
@@ -386,7 +382,6 @@ func (r *Repository) GetUsedProjectList(ctx context.Context, db Queryer, pageSql
 				WHERE RNUM > :2`, condition, retryCondition, order)
 
 	if err := db.SelectContext(ctx, &list, query, pageSql.EndNum, pageSql.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetUsedProjectList err: %w", err)
 	}
 
@@ -432,7 +427,6 @@ func (r *Repository) GetUsedProjectCount(ctx context.Context, db Queryer, search
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetUsedProjectCount err: %v", err)
 	}
 
@@ -522,7 +516,6 @@ func (r *Repository) GetAllProjectList(ctx context.Context, db Queryer, pageSql 
 				WHERE RNUM > :3`, condition, retryCondition, order)
 
 	if err := db.SelectContext(ctx, &list, query, isAll, pageSql.EndNum, pageSql.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetAllProjectList err: %w", err)
 	}
 
@@ -568,7 +561,6 @@ func (r *Repository) GetAllProjectCount(ctx context.Context, db Queryer, search 
 				WHERE %s %s`, condition, retryCondition)
 
 	if err := db.GetContext(ctx, &count, query); err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetAllProjectCount err: %w", err)
 	}
 
@@ -638,7 +630,6 @@ func (r *Repository) GetStaffProjectList(ctx context.Context, db Queryer, pageSq
 			WHERE RNUM > :3`, condition, order)
 
 	if err := db.SelectContext(ctx, &list, query, uno, pageSql.EndNum, pageSql.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetStaffProjectList err: %w", err)
 	}
 
@@ -677,7 +668,6 @@ func (r *Repository) GetStaffProjectCount(ctx context.Context, db Queryer, searc
 				WHERE %s`, condition)
 
 	if err := db.GetContext(ctx, &count, query, uno); err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetStaffProjectCount err: %w", err)
 	}
 
@@ -705,7 +695,6 @@ func (r *Repository) GetProjectNmUnoList(ctx context.Context, db Queryer, uno sq
 			      JNO DESC`
 
 	if err := db.SelectContext(ctx, &projectInfos, query, role, uno); err != nil {
-		//TODO: 에러 아카이브
 		return &projectInfos, fmt.Errorf("GetProjectNmList fail: %v", err)
 	}
 
@@ -775,7 +764,6 @@ func (r *Repository) GetNonUsedProjectList(ctx context.Context, db Queryer, page
 								WHERE RNUM > :2`, condition, retryCondition, order)
 
 	if err := db.SelectContext(ctx, &nonProjects, query, page.EndNum, page.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return &nonProjects, fmt.Errorf("GetNonUsedProjectList fail: %v", err)
 	}
 
@@ -820,7 +808,6 @@ func (r *Repository) GetNonUsedProjectCount(ctx context.Context, db Queryer, sea
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, nil
 		}
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetNonUsedProjectCount fail: %v", err)
 	}
 
@@ -862,7 +849,6 @@ func (r *Repository) AddProject(ctx context.Context, tx Execer, project entity.R
 			)`
 
 	if _, err := tx.ExecContext(ctx, query, project.Sno, project.Jno, agent, project.RegUser, project.RegUno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("AddProject. Failed to add project: %w", err)
 	}
 	return nil
@@ -883,7 +869,6 @@ func (r *Repository) ModifyDefaultProject(ctx context.Context, tx Execer, projec
 		    MOD_DATE = SYSDATE
 		WHERE SNO = :4`
 	if _, err := tx.ExecContext(ctx, query, agent, project.ModUser, project.ModUno, project.Sno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyDefaultProject; IS_DEFAULT 'N'. Failed to modify default project: %w", err)
 	}
 
@@ -897,7 +882,6 @@ func (r *Repository) ModifyDefaultProject(ctx context.Context, tx Execer, projec
 		WHERE SNO = :4
 		AND JNO = :5`
 	if _, err := tx.ExecContext(ctx, query, agent, project.ModUser, project.ModUno, project.Sno, project.Jno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyDefaultProject IS_DEFAULT 'Y'. Failed to modify default project: %w", err)
 	}
 
@@ -920,7 +904,6 @@ func (r *Repository) ModifyUseProject(ctx context.Context, tx Execer, project en
 		WHERE SNO = :5
 		AND JNO = :6`
 	if _, err := tx.ExecContext(ctx, query, project.IsUsed, agent, project.ModUser, project.ModUno, project.Sno, project.Jno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyUseProject. Failed to modify default project: %w", err)
 	}
 	return nil
@@ -935,7 +918,6 @@ func (r *Repository) RemoveProject(ctx context.Context, tx Execer, sno int64, jn
 		WHERE SNO = :1
 		AND JNO = :2`
 	if _, err := tx.ExecContext(ctx, query, sno, jno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("RemoveProject. Failed to modify default project: %w", err)
 	}
 	return nil

--- a/csm-api/store/store_project_daily.go
+++ b/csm-api/store/store_project_daily.go
@@ -48,7 +48,6 @@ func (r *Repository) GetProjectDailyContentList(ctx context.Context, db Queryer,
 				NVL(t1.REG_DATE, t1.MOD_DATE) DESC`
 
 	if err := db.SelectContext(ctx, &projectDailys, sql, jnoParam, targetDateParam); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetProjectDailyContentList fail: %w", err)
 	}
 	return &projectDailys, nil

--- a/csm-api/store/store_project_setting.go
+++ b/csm-api/store/store_project_setting.go
@@ -77,7 +77,6 @@ func (r *Repository) MergeManHour(ctx context.Context, tx Execer, manHour entity
 		`
 	result, err := tx.ExecContext(ctx, query, manHour.Mhno, manHour.WorkHour, manHour.ManHour, manHour.Jno, manHour.Etc, manHour.RegUno, manHour.RegUser)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("MargeManHour err: %w", err)
 	}
 
@@ -96,7 +95,6 @@ func (r *Repository) AddManHour(ctx context.Context, tx Execer, manHour entity.M
 		`
 	_, err := tx.ExecContext(ctx, query, manHour.WorkHour, manHour.ManHour, manHour.Jno, manHour.Etc, manHour.RegUno, manHour.RegUser)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("Store/AddManHour err: %w", err)
 	}
 	return nil
@@ -146,7 +144,6 @@ func (r *Repository) MergeProjectSetting(ctx context.Context, tx Execer, project
 			)`
 	result, err := tx.ExecContext(ctx, query, project.Jno, project.InTime, project.OutTime, project.RespiteTime, project.CancelCode, project.RegUno, project.RegUser)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("MergeProject. Failed to modify project setting: %w", err)
 	}
 
@@ -170,7 +167,6 @@ func (r *Repository) GetCheckProjectSetting(ctx context.Context, db Queryer) (pr
 				    JNO NOT IN (SELECT JNO FROM IRIS_JOB_SET)`
 
 	if err = db.SelectContext(ctx, projects, query); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetCheckProjectSetting err: %w", err)
 	}
 
@@ -201,7 +197,6 @@ func (r *Repository) GetProjectSetting(ctx context.Context, db Queryer, jno int6
 			`)
 
 	if err := db.SelectContext(ctx, &setting, query, jno); err != nil {
-		//TODO: 에러 아카이브
 		return &setting, fmt.Errorf("GetProjectSetting fail: %v", err)
 	}
 
@@ -220,7 +215,6 @@ func (r *Repository) DeleteManHour(ctx context.Context, tx Execer, mhno int64) e
 			`)
 	result, err := tx.ExecContext(ctx, query, mhno)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("DeleteManHour fail: %v", err)
 	} else if count, _ := result.RowsAffected(); count <= 0 {
 		return fmt.Errorf("Deleted ManHour is Zero")
@@ -239,7 +233,6 @@ func (r *Repository) ProjectSettingLog(ctx context.Context, tx Execer, setting e
 	`)
 
 	if _, err := tx.ExecContext(ctx, query, setting.Jno, setting.Message, setting.RegUser, setting.RegUno, agent); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("ProjectSettingLog fail: %v", err)
 	}
 
@@ -256,7 +249,6 @@ func (r *Repository) ManHourLog(ctx context.Context, tx Execer, manhour entity.M
 	`)
 
 	if _, err := tx.ExecContext(ctx, query, manhour.Jno, manhour.Message, manhour.RegUser, manhour.RegUno, agent); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("ManHourLog fail: %v", err)
 	}
 

--- a/csm-api/store/store_site.go
+++ b/csm-api/store/store_site.go
@@ -65,7 +65,6 @@ func (r *Repository) GetSiteList(ctx context.Context, db Queryer, targetDate tim
 				ORDER BY t1.SNO DESC`
 
 	if err := db.SelectContext(ctx, &sites, sql, role, uno, targetDate); err != nil {
-		//TODO: 에러 아카이브
 		return &sites, fmt.Errorf("getSiteList fail: %w", err)
 	}
 
@@ -121,7 +120,6 @@ func (r *Repository) GetSiteNmList(ctx context.Context, db Queryer, page entity.
 				) WHERE RNUM > :3`, condition, order)
 
 	if err := db.SelectContext(ctx, &sites, query, nonSite, page.EndNum, page.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return &sites, fmt.Errorf("getSiteNmList fail: %w", err)
 	}
 	return &sites, nil
@@ -150,7 +148,6 @@ func (r *Repository) GetSiteNmCount(ctx context.Context, db Queryer, search enti
 				    `, condition)
 
 	if err := db.GetContext(ctx, &count, query, nonSite); err != nil {
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("getSiteNmList fail: %w", err)
 	}
 	return count, nil
@@ -184,7 +181,6 @@ func (r *Repository) GetSiteStatsList(ctx context.Context, db Queryer, targetDat
 					GROUP BY SNO
 				) T3 ON T1.SNO = T3.SNO`
 	if err := db.SelectContext(ctx, &sites, query, targetDate, targetDate); err != nil {
-		//TODO: 에러 아카이브
 		return &sites, fmt.Errorf("getSiteStatsList fail: %w", err)
 	}
 	return &sites, nil
@@ -209,7 +205,6 @@ func (r *Repository) ModifySite(ctx context.Context, tx Execer, site entity.Site
 			    SNO = :6
 			`
 	if _, err := tx.ExecContext(ctx, query, site.SiteNm, site.Etc, site.ModUno, site.ModUser, agent, site.Sno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("store/site. ModifySite fail: %v", err)
 	}
 
@@ -225,7 +220,6 @@ func (r *Repository) AddSite(ctx context.Context, db Queryer, tx Execer, jno int
 	// sno 생성
 	query := `SELECT SEQ_IRIS_SITE_SET.NEXTVAL FROM DUAL`
 	if err := db.GetContext(ctx, &generatedSNO, query); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("store/site. Failed to get generated SITE_SET_SEQ.NEXTVAL: %w", err)
 	}
 	// IRIS_SITE_SET 생성
@@ -240,7 +234,6 @@ func (r *Repository) AddSite(ctx context.Context, db Queryer, tx Execer, jno int
 			FROM s_job_info 
 			WHERE JNO = :5`
 	if _, err := tx.ExecContext(ctx, query, generatedSNO, user.Agent, user.UserName, user.Uno, jno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("IRIS_SITE_SET INSERT failed: %w", err)
 	}
 
@@ -254,7 +247,6 @@ func (r *Repository) AddSite(ctx context.Context, db Queryer, tx Execer, jno int
 				:3, :4, :5
 			)`
 	if _, err := tx.ExecContext(ctx, query, generatedSNO, jno, user.Agent, user.UserName, user.Uno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("IRIS_SITE_JOB INSERT failed: %w", err)
 	}
 
@@ -270,7 +262,6 @@ func (r *Repository) AddSite(ctx context.Context, db Queryer, tx Execer, jno int
 			FROM s_job_info
 			WHERE JNO = :5`
 	if _, err := tx.ExecContext(ctx, query, generatedSNO, user.Agent, user.UserName, user.Uno, jno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("IRIS_SITE_DATE INSERT failed: %w", err)
 	}
 

--- a/csm-api/store/store_site_date.go
+++ b/csm-api/store/store_site_date.go
@@ -30,7 +30,6 @@ func (r *Repository) GetSiteDateData(ctx context.Context, db Queryer, sno int64)
 		if errors.Is(err, sql.ErrNoRows) {
 			return &siteDate, nil
 		}
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetSiteDateData fail: %w", err)
 	}
 	return &siteDate, nil

--- a/csm-api/store/store_site_pos.go
+++ b/csm-api/store/store_site_pos.go
@@ -64,7 +64,6 @@ func (r *Repository) GetSitePosData(ctx context.Context, db Queryer, sno int64) 
 		if errors.Is(err, sql.ErrNoRows) {
 			return &sitePos, nil
 		}
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetSitePosData fail: %v", err)
 	}
 
@@ -168,7 +167,6 @@ func (r *Repository) ModifySitePosData(ctx context.Context, tx Execer, sno int64
 		sitePosSql.RoadAddress,
 		sitePosSql.ZoneCode,
 		sitePosSql.BuildingName); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("store/site_pos. ModifySitePosData fail: %v", err)
 	}
 

--- a/csm-api/store/store_user.go
+++ b/csm-api/store/store_user.go
@@ -33,7 +33,6 @@ func (r *Repository) GetUserInfoPeList(ctx context.Context, db Queryer, unoList 
 			WHERE t1.UNO IN (%s)`, strings.Join(placeholders, ","))
 
 	if err := db.SelectContext(ctx, &userPeInfos, sql, args...); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetUserInfoPeList fail: %w", err)
 	}
 

--- a/csm-api/store/store_weather.go
+++ b/csm-api/store/store_weather.go
@@ -21,7 +21,6 @@ func (r *Repository) SaveWeather(ctx context.Context, tx Execer, weather entity.
 		`
 
 	if _, err := tx.ExecContext(ctx, query, weather.Sno, weather.Lgt, weather.Pty, weather.Rn1, weather.Sky, weather.T1h, weather.Reh, weather.Uuu, weather.Vvv, weather.Vec, weather.Wsd, weather.RecogTime); err != nil {
-		// TODO: 에러 아카이브
 		return fmt.Errorf("IRIS_WEATHER INSERT failed: %w", err)
 	}
 
@@ -42,7 +41,6 @@ func (r *Repository) GetWeatherList(ctx context.Context, db Queryer, sno int64, 
 		`
 
 	if err := db.SelectContext(ctx, &weathers, query, sno, targetDate); err != nil {
-		// TODO: 에러 아카이브
 		return nil, fmt.Errorf("IRIS_WEATHER LIST failed: %w", err)
 	}
 

--- a/csm-api/store/store_worker.go
+++ b/csm-api/store/store_worker.go
@@ -112,7 +112,6 @@ func (r *Repository) GetWorkerTotalList(ctx context.Context, db Queryer, page en
 				WHERE RNUM > :2`, condition, retryCondition, order, page.RnumOrder)
 
 	if err := db.SelectContext(ctx, &workers, query, page.EndNum, page.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetWorkerTotalList err: %v", err)
 	}
 
@@ -150,10 +149,8 @@ func (r *Repository) GetWorkerTotalCount(ctx context.Context, db Queryer, search
 
 	if err := db.GetContext(ctx, &count, query); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			//TODO: 에러 아카이브
 			return 0, nil
 		}
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetWorkerTotalCount fail: %w", err)
 	}
 	return count, nil
@@ -192,7 +189,6 @@ func (r *Repository) GetAbsentWorkerList(ctx context.Context, db Queryer, page e
 				WHERE RNUM > :6`, retryCondition)
 
 	if err := db.SelectContext(ctx, &workers, query, search.SearchStartTime, search.Jno, search.Jno, search.SearchStartTime, page.EndNum, page.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetAbsentWorkerList fail: %v", err)
 	}
 
@@ -225,10 +221,8 @@ func (r *Repository) GetAbsentWorkerCount(ctx context.Context, db Queryer, searc
 
 	if err := db.GetContext(ctx, &count, query, search.Jno, search.Jno, search.SearchStartTime); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			//TODO: 에러 아카이브
 			return 0, nil
 		}
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetAbsentWorkerCount fail: %w", err)
 	}
 	return count, nil
@@ -278,7 +272,6 @@ func (r *Repository) AddWorker(ctx context.Context, tx Execer, worker entity.Wor
 		agent, worker.RegUser, worker.RegUno, worker.RegNo,
 	)
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("AddWorker; IRIS_WORKER_SET INSERT fail: %v", err)
 	}
 
@@ -307,17 +300,14 @@ func (r *Repository) ModifyWorker(ctx context.Context, tx Execer, worker entity.
 	)
 
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyWorker fail: %v", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyWorker RowsAffected fail: %v", err)
 	}
 	if rowsAffected == 0 {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("Rows add/update cnt: %d\n", rowsAffected)
 	}
 
@@ -396,7 +386,6 @@ func (r *Repository) GetWorkerSiteBaseList(ctx context.Context, db Queryer, page
 				WHERE RNUM > :5`, condition, retryCondition, order, page.RnumOrder)
 
 	if err := db.SelectContext(ctx, &list, query, search.Jno, search.SearchStartTime, search.SearchEndTime, page.EndNum, page.StartNum); err != nil {
-		//TODO: 에러 아카이브
 		return nil, fmt.Errorf("GetWorkerSiteBaseList err: %v", err)
 	}
 
@@ -434,10 +423,8 @@ func (r *Repository) GetWorkerSiteBaseCount(ctx context.Context, db Queryer, sea
 
 	if err := db.GetContext(ctx, &count, query, search.Jno, search.SearchStartTime, search.SearchEndTime); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			//TODO: 에러 아카이브
 			return 0, nil
 		}
-		//TODO: 에러 아카이브
 		return 0, fmt.Errorf("GetWorkerSiteBaseCount fail: %w", err)
 	}
 	return count, nil
@@ -500,7 +487,6 @@ func (r *Repository) MergeSiteBaseWorker(ctx context.Context, tx Execer, workers
 			worker.WorkState, worker.IsOvertime, worker.WorkHour,
 		)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("MergeSiteBaseWorker fail: %w", err)
 		}
 	}
@@ -549,7 +535,6 @@ func (r *Repository) ModifyWorkerDeadline(ctx context.Context, tx Execer, worker
 			worker.UserId, worker.RecordDate,
 		)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("ModifyWorkerDeadline fail: %w", err)
 		}
 	}
@@ -582,7 +567,6 @@ func (r *Repository) ModifyWorkerProject(ctx context.Context, tx Execer, workers
 			worker.Jno, worker.UserId, worker.RecordDate,
 		)
 		if err != nil {
-			//TODO: 에러 아카이브
 			return fmt.Errorf("ModifyWorkerProject fail: %w", err)
 		}
 	}
@@ -638,7 +622,6 @@ func (r *Repository) ModifyWorkerDeadlineInit(ctx context.Context, tx Execer) er
 			AND COMPARE_STATE = 'S'`
 
 	if _, err := tx.ExecContext(ctx, query, agent); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyWorkerDeadlineInit fail: %w", err)
 	}
 
@@ -698,7 +681,6 @@ func (r *Repository) ModifyWorkerOverTime(ctx context.Context, tx Execer, worker
 	`
 
 	if _, err := tx.ExecContext(ctx, query, workerOverTime.OutRecogTime, agent, workerOverTime.BeforeCno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("ModifyWorkerOverTime fail: %w", err)
 	}
 	return nil
@@ -715,7 +697,6 @@ func (r *Repository) DeleteWorkerOverTime(ctx context.Context, tx Execer, cno nu
 		WHERE  CNO = :1
 		`
 	if _, err := tx.ExecContext(ctx, query, cno); err != nil {
-		//TODO: 에러 아카이브
 		return fmt.Errorf("DeleteWorkerOverTime fail: %w", err)
 	}
 	return nil


### PR DESCRIPTION
에러 발생시 해당 메세지를 에러로그파일에 기록이 되도록 log.go 파일에 WriteErrorLog(...)를 작성. 에러가 리턴받는 최상단 위치인 response.go, init.go, sheduler.go에 WriteErrorLog()를 추가하고 예기치 못한 에러가 발생했을 때를 대비하여 main.go의 main()함수에도 추가함. WriteErrorLog() 반환 error에 랩핑하여 main()에서 에러메세지가 중복 기록되지 않게 함.