### PR TITLE
젠킨스 파이프라인 컨테이너 실행 수정

### DIFF
--- a/jenkins/jenkins-pipeline-scipt-csm-api
+++ b/jenkins/jenkins-pipeline-scipt-csm-api
@@ -90,6 +90,8 @@ pipeline {
 						  --network "\${DOCKER_NETWORK}" \
 						  --restart=unless-stopped \
 						  -p 8080:8080 \
+						  -v /etc/localtime:/etc/localtime:ro \
+                          -v /etc/timezone:/etc/timezone:ro \
 						  -v /tmp/data/csm:/tmp/data/csm \
 						  "\${IMAGE_NAME}:latest"
                     '


### PR DESCRIPTION
컨테이너 내부 시간과 호스트 시간이 불일치하는 문제를 해결하기 위해
/etc/localtime 및 /etc/timezone을 읽기 전용으로 마운트