### PR TITLE
[시스템관리] 시스템 관리 페이지 api 구현 및 공정률 날짜 지정하여 세팅

### DIFF
--- a/csm-api/handler/handler_init.go
+++ b/csm-api/handler/handler_init.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 )
 
 type InitApiHandler struct {
@@ -62,9 +63,12 @@ func (h *InitApiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 당일 공정률 기록
-	if count, err := h.SiteService.SettingWorkRate(ctx); err != nil {
+	now := time.Now()
+	if count, err := h.SiteService.SettingWorkRate(ctx, now); err != nil {
 		log.Printf("[InitApi] SettingWorkRate fail: %w", err)
 	} else if count > 0 {
 		log.Printf("[InitApi] SettingWorkRate success: %d", count)
 	}
+
+	SuccessResponse(ctx, w)
 }

--- a/csm-api/handler/handler_system.go
+++ b/csm-api/handler/handler_system.go
@@ -1,0 +1,136 @@
+package handler
+
+import (
+	"csm-api/entity"
+	"csm-api/service"
+	"csm-api/utils"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+type SystemHandler struct {
+	WorkerService         service.WorkerService
+	WorkHourService       service.WorkHourService
+	ProjectService        service.ProjectService
+	ProjectSettingService service.ProjectSettingService
+	WeatherService        service.WeatherApiService
+	SiteService           service.SiteService
+}
+
+// 근로자 마감 처리
+func (h *SystemHandler) WorkerDeadline(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if err := h.WorkerService.ModifyWorkerDeadlineInit(ctx); err != nil {
+		_ = entity.WriteErrorLog(ctx, fmt.Errorf("ModifyWorkerDeadlineInit fail: %+v", err))
+		FailResponse(ctx, w, err)
+		return
+
+	} else {
+		log.Println("ModifyWorkerDeadlineInit completed")
+	}
+
+	SuccessResponse(ctx, w)
+}
+
+// 철야 확인 작업
+func (h *SystemHandler) WorkerOverTime(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if count, err := h.WorkerService.ModifyWorkerOverTime(ctx); err != nil {
+		_ = entity.WriteErrorLog(ctx, fmt.Errorf("ModifyWorkerOverTime fail: %+v", err))
+		FailResponse(ctx, w, err)
+		return
+
+	} else if count != 0 {
+		log.Println("ModifyWorkerOverTime completed")
+	}
+
+	SuccessResponse(ctx, w)
+}
+
+// 프로젝트 정보 업데이트(초기 세팅)
+func (h *SystemHandler) ProjectInitSetting(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if count, err := h.ProjectSettingService.CheckProjectSetting(ctx); err != nil {
+		_ = entity.WriteErrorLog(ctx, fmt.Errorf("CheckProjectSettings fail: %+v", err))
+		FailResponse(ctx, w, err)
+		return
+
+	} else if count != 0 {
+		log.Printf("CheckProjectSettings %d completed \n", count)
+	}
+
+	SuccessResponse(ctx, w)
+}
+
+// 근로자 공수 계산(마감처리 안되고, 출퇴근이 모두 있는 근로자)
+func (h *SystemHandler) UpdateWorkHour(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	user := entity.Base{
+		ModUser: utils.ParseNullString("SYSTEM_BATCH"),
+	}
+
+	if err := h.WorkHourService.ModifyWorkHour(ctx, user); err != nil {
+		_ = entity.WriteErrorLog(ctx, fmt.Errorf("ModifyWorkHour fail: %+v", err))
+		FailResponse(ctx, w, err)
+		return
+
+	} else {
+		log.Println("ModifyWorkHour completed")
+	}
+
+	SuccessResponse(ctx, w)
+}
+
+// 당일 공정률 기록
+func (h *SystemHandler) SettingWorkRate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	targetDateString := r.URL.Query().Get("targetDate")
+	if targetDateString == "" {
+		BadRequestResponse(ctx, w)
+		return
+	}
+	targetDate, err := time.Parse("2006-01-02", targetDateString)
+	if err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+
+	var count int64 = 0
+	if count, err = h.SiteService.SettingWorkRate(ctx, targetDate); err != nil {
+		log.Printf("SettingWorkRate fail: %w", err)
+		FailResponse(ctx, w, err)
+		return
+
+	} else if count > 0 {
+		log.Printf("SettingWorkRate success: %d", count)
+	}
+
+	SuccessResponse(ctx, w)
+}
+
+// 공수 추가
+func (h *SystemHandler) AddManHour(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	manhour := entity.ManHour{}
+	if err := json.NewDecoder(r.Body).Decode(&manhour); err != nil {
+		FailResponse(r.Context(), w, err)
+		return
+	}
+
+	if err := h.ProjectSettingService.AddManHour(ctx, manhour); err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+
+	SuccessResponse(ctx, w)
+
+}

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -66,24 +66,25 @@ func newMux(ctx context.Context, safeDb *sqlx.DB, timesheetDb *sqlx.DB) (http.Ha
 		//		next.ServeHTTP(w, r)
 		//	})
 		//})
-		router.Mount("/menu", route.MenuRoute(safeDb, &r))                      // 메뉴
-		router.Mount("/user", route.UserRoute(safeDb, timesheetDb, &r))         // 사용자 {권한}
-		router.Mount("/api", route.ApiRoute(apiCfg, safeDb, &r))                // api
-		router.Mount("/excel", route.ExcelRoute(safeDb, &r))                    // 엑셀
-		router.Mount("/project", route.ProjectRoute(safeDb, &r))                // 프로젝트
-		router.Mount("/organization", route.OrganiztionRoute(timesheetDb, &r))  // 조직도
-		router.Mount("/site", route.SiteRoute(safeDb, timesheetDb, &r, apiCfg)) // 현장
-		router.Mount("/worker", route.WorkerRoute(safeDb, &r))                  // 근로자
-		router.Mount("/compare", route.CompareRoute(safeDb, &r))                // 일일 근로자 비교
-		router.Mount("/deadline", route.DeadlineRoute(safeDb, &r))              // 일일마감
-		router.Mount("/equip", route.EquipRoute(safeDb, &r))                    // 장비 (임시)
-		router.Mount("/device", route.DeviceRoute(safeDb, &r))                  // 근태인식기
-		router.Mount("/company", route.CompanyRoute(safeDb, timesheetDb, &r))   // 협력업체
-		router.Mount("/schedule", route.ScheduleRoute(safeDb, &r))              // 일정관리
-		router.Mount("/notice", route.NoticeRoute(safeDb, &r))                  // 공지사항
-		router.Mount("/code", route.CodeRoute(safeDb, &r))                      // 코드
-		router.Mount("/project-setting", route.ProjectSettingRoute(safeDb, &r)) // 프로젝트 설정
-		router.Mount("/user-role", route.UserRoleRoute(safeDb, &r))             // 사용자 권한
+		router.Mount("/menu", route.MenuRoute(safeDb, &r))                          // 메뉴
+		router.Mount("/user", route.UserRoute(safeDb, timesheetDb, &r))             // 사용자 {권한}
+		router.Mount("/api", route.ApiRoute(apiCfg, safeDb, &r))                    // api
+		router.Mount("/excel", route.ExcelRoute(safeDb, &r))                        // 엑셀
+		router.Mount("/project", route.ProjectRoute(safeDb, &r))                    // 프로젝트
+		router.Mount("/organization", route.OrganiztionRoute(timesheetDb, &r))      // 조직도
+		router.Mount("/site", route.SiteRoute(safeDb, timesheetDb, &r, apiCfg))     // 현장
+		router.Mount("/worker", route.WorkerRoute(safeDb, &r))                      // 근로자
+		router.Mount("/compare", route.CompareRoute(safeDb, &r))                    // 일일 근로자 비교
+		router.Mount("/deadline", route.DeadlineRoute(safeDb, &r))                  // 일일마감
+		router.Mount("/equip", route.EquipRoute(safeDb, &r))                        // 장비 (임시)
+		router.Mount("/device", route.DeviceRoute(safeDb, &r))                      // 근태인식기
+		router.Mount("/company", route.CompanyRoute(safeDb, timesheetDb, &r))       // 협력업체
+		router.Mount("/schedule", route.ScheduleRoute(safeDb, &r))                  // 일정관리
+		router.Mount("/notice", route.NoticeRoute(safeDb, &r))                      // 공지사항
+		router.Mount("/code", route.CodeRoute(safeDb, &r))                          // 코드
+		router.Mount("/project-setting", route.ProjectSettingRoute(safeDb, &r))     // 프로젝트 설정
+		router.Mount("/user-role", route.UserRoleRoute(safeDb, &r))                 // 사용자 권한
+		router.Mount("/system", route.SystemRoute(safeDb, timesheetDb, apiCfg, &r)) // 시스템관리
 	})
 
 	return c.Handler(mux), nil

--- a/csm-api/route/router_system.go
+++ b/csm-api/route/router_system.go
@@ -1,0 +1,71 @@
+package route
+
+import (
+	"csm-api/config"
+	"csm-api/handler"
+	"csm-api/service"
+	"csm-api/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+)
+
+func SystemRoute(safeDb *sqlx.DB, timesheetDb *sqlx.DB, apiCfg *config.ApiConfig, r *store.Repository) chi.Router {
+
+	router := chi.NewRouter()
+
+	systemHandler := &handler.SystemHandler{
+
+		WorkerService: &service.ServiceWorker{
+			SafeDB:  safeDb,
+			SafeTDB: safeDb,
+			Store:   r,
+		},
+		WorkHourService: &service.ServiceWorkHour{
+			SafeDB:  safeDb,
+			SafeTDB: safeDb,
+			Store:   r,
+		},
+		ProjectService: &service.ServiceProject{
+			SafeDB:  safeDb,
+			SafeTDB: safeDb,
+			Store:   r,
+		},
+		ProjectSettingService: &service.ServiceProjectSetting{
+			SafeDB:        safeDb,
+			SafeTDB:       safeDb,
+			Store:         r,
+			WorkHourStore: r,
+		},
+		WeatherService: &service.ServiceWeather{
+			ApiKey:       apiCfg,
+			SafeDB:       safeDb,
+			SafeTDB:      safeDb,
+			Store:        r,
+			SitePosStore: r,
+		},
+		SiteService: &service.ServiceSite{
+			SafeDB:            safeDb,
+			SafeTDB:           safeDb,
+			Store:             r,
+			ProjectStore:      r,
+			ProjectDailyStore: r,
+			SitePosStore:      r,
+			SiteDateStore:     r,
+			UserService: &service.ServiceUser{
+				SafeDB:      safeDb,
+				TimeSheetDB: timesheetDb,
+				Store:       r,
+			},
+		},
+	}
+
+	router.Get("/worker-deadline", systemHandler.WorkerDeadline)     // 근로자 마감 처리
+	router.Get("/worker-overtime", systemHandler.WorkerOverTime)     // 철야 확인 작업
+	router.Get("/project-setting", systemHandler.ProjectInitSetting) // 프로젝트 정보 업데이트
+	router.Get("/update-workhour", systemHandler.UpdateWorkHour)     // 근로자 공수 계산
+	router.Get("/setting-workrate", systemHandler.SettingWorkRate)   // 당일 공정률 기록
+	router.Post("/manhour", systemHandler.AddManHour)                // 공수 추가
+
+	return router
+
+}

--- a/csm-api/scheduler.go
+++ b/csm-api/scheduler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/robfig/cron/v3"
 	"log"
+	"time"
 )
 
 /**
@@ -176,7 +177,8 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	_, err = s.cron.AddFunc("0 0 0,1,2,3,4,5 * * *", func() {
 		log.Println("[Scheduler] Running SettingWorkRate")
 		var count int64
-		count, err = s.SiteService.SettingWorkRate(ctx)
+		now := time.Now()
+		count, err = s.SiteService.SettingWorkRate(ctx, now)
 		if err != nil {
 			log.Printf("[Scheduler] SettingWorkRate fail: %w", err)
 		} else if count > 0 {

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -24,7 +24,7 @@ type SiteService interface {
 	ModifySite(ctx context.Context, site entity.Site) error
 	AddSite(ctx context.Context, jno int64, user entity.User) error
 	ModifySiteIsNonUse(ctx context.Context, site entity.ReqSite) error
-	SettingWorkRate(ctx context.Context) (int64, error)
+	SettingWorkRate(ctx context.Context, targetDate time.Time) (int64, error)
 	ModifyWorkRate(ctx context.Context, workRate entity.SiteWorkRate) error
 	GetSiteWorkRateByDate(ctx context.Context, jno int64, month string) (entity.SiteWorkRate, error)
 }
@@ -67,6 +67,7 @@ type ProjectSettingService interface {
 	MergeProjectSetting(ctx context.Context, project entity.ProjectSetting) error
 	CheckProjectSetting(ctx context.Context) (count int, err error)
 	DeleteManHour(ctx context.Context, mhno int64, manhour entity.ManHour) error
+	AddManHour(ctx context.Context, manhour entity.ManHour) error
 }
 
 type OrganizationService interface {

--- a/csm-api/service/service_site.go
+++ b/csm-api/service/service_site.go
@@ -368,7 +368,7 @@ func (s *ServiceSite) ModifySiteIsNonUse(ctx context.Context, site entity.ReqSit
 // func: 공정률 전날 수치로 세팅
 // @param
 // -
-func (s *ServiceSite) SettingWorkRate(ctx context.Context) (int64, error) {
+func (s *ServiceSite) SettingWorkRate(ctx context.Context, targetDate time.Time) (int64, error) {
 	tx, err := s.SafeTDB.BeginTx(ctx, nil)
 	if err != nil {
 		// TODO: 에러 아카이브
@@ -385,7 +385,7 @@ func (s *ServiceSite) SettingWorkRate(ctx context.Context) (int64, error) {
 			}
 		}
 	}()
-	count, err := s.Store.SettingWorkRate(ctx, tx)
+	count, err := s.Store.SettingWorkRate(ctx, tx, targetDate)
 	if err != nil {
 		return 0, fmt.Errorf("service_site/SettingWorkRate err: %w", err)
 	}

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -26,7 +26,7 @@ type SiteStore interface {
 	ModifySite(ctx context.Context, tx Execer, site entity.Site) error
 	AddSite(ctx context.Context, db Queryer, tx Execer, jno int64, user entity.User) error
 	ModifySiteIsNonUse(ctx context.Context, tx Execer, site entity.ReqSite) error
-	SettingWorkRate(ctx context.Context, tx Execer) (int64, error)
+	SettingWorkRate(ctx context.Context, tx Execer, targetDate time.Time) (int64, error)
 	ModifyWorkRate(ctx context.Context, tx Execer, workRate entity.SiteWorkRate) error
 	GetSiteWorkRateByDate(ctx context.Context, db Queryer, jno int64, month string) (entity.SiteWorkRate, error)
 }

--- a/csm-api/store/store_project_setting.go
+++ b/csm-api/store/store_project_setting.go
@@ -35,7 +35,7 @@ func (r *Repository) GetManHourList(ctx context.Context, db Queryer, jno int64) 
 	return &manHours, nil
 }
 
-// func: 공수 수정 및 추가
+// func: 공수 수정 및 추가(시스템 관리자)
 // @param
 // - manHour: 공수 정보
 func (r *Repository) MergeManHour(ctx context.Context, tx Execer, manHour entity.ManHour) (count int64, err error) {


### PR DESCRIPTION
1. 시스템 관리 페이지 api
  - 근로자 마감처리: GET system/worker-deadline
  - 철야 확인 작업: GET system/worker-overtime
  - 프로젝트 정보 업데이트: GET system/project-setting
  - 근로자 공수 계산: GET system/update-workhour
  - 당일 공정률 기록: GET system/setting-workrate
  - 공수 추가: POST system/manhour

2. 공정률 날짜 지정하여 세팅
  - 지정한 날짜보다 이전 날짜들의 공정률 중 가장 최근 데이터를 저장.