### PR TITLE
defer 헬퍼함수 수정

### DIFF
--- a/csm-api/service/service_notice.go
+++ b/csm-api/service/service_notice.go
@@ -7,6 +7,7 @@ import (
 	"csm-api/store"
 	"csm-api/txutil"
 	"csm-api/utils"
+	"fmt"
 	"github.com/guregu/null"
 )
 
@@ -99,7 +100,7 @@ func (s *ServiceNotice) AddNotice(ctx context.Context, notice entity.Notice) (er
 	defer txutil.DeferTx(tx, &err)
 
 	if err = s.Store.AddNotice(ctx, tx, notice); err != nil {
-		return utils.CustomErrorf(err)
+		return fmt.Errorf("service_notice/AddNotice err : %w", err)
 	}
 
 	return

--- a/csm-api/store/repository.go
+++ b/csm-api/store/repository.go
@@ -19,7 +19,7 @@ func New(ctx context.Context, cfg *config.DBConfig) (*sqlx.DB, func(), error) {
 	var P godror.ConnectionParams
 	P.Username = cfg.UserName
 	P.Password = godror.NewPassword(cfg.Password)
-	P.ConnectString = fmt.Sprintf("%s:%s/%s", cfg.Host, cfg.Port, cfg.OracleSid)
+	P.ConnectString = fmt.Sprintf("%s:%s/%s?_enableTxReadWrite=0", cfg.Host, cfg.Port, cfg.OracleSid)
 	P.Timezone = time.FixedZone("Asia/Seoul", 9*60*60) // 애플리케이션 타임존 설정
 	P.SetSessionParamOnInit("TIME_ZONE", "Asia/Seoul") // 세션 타임존 설정
 
@@ -54,6 +54,7 @@ type Repository struct {
 type Beginner interface {
 	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 	BeginTxx(ctx context.Context, opts *sql.TxOptions) (*sqlx.Tx, error)
+	Conn(ctx context.Context) (*sql.Conn, error)
 }
 
 type Preparer interface {

--- a/csm-api/txutil/tx.go
+++ b/csm-api/txutil/tx.go
@@ -10,6 +10,10 @@ import (
 )
 
 func DeferTx(tx *sql.Tx, err *error) {
+	if tx == nil {
+		return
+	}
+
 	if r := recover(); r != nil {
 		_ = tx.Rollback()
 		*err = utils.CustomMessageErrorfDepth(2, "panic", fmt.Errorf("%v", r))
@@ -29,10 +33,11 @@ func DeferTx(tx *sql.Tx, err *error) {
 
 func BeginTxWithMode(ctx context.Context, db store.Beginner, readOnly bool) (*sql.Tx, error) {
 	opts := &sql.TxOptions{
-		ReadOnly: readOnly,
+		ReadOnly: false,
 	}
 
-	tx, err := db.BeginTx(ctx, opts)
+	conn, err := db.Conn(ctx)
+	tx, err := conn.BeginTx(ctx, opts)
 	if err != nil {
 		return nil, utils.CustomMessageErrorfDepth(2, "begin tx", err)
 	}


### PR DESCRIPTION
공지사항 서비스를 실행할때 트랜잭션 실행시 이미 트랜잭션을 사용중이라는 에러가 계속해서 발생하여 실행시마다 새로운 커넥셔을 만들어서 사용하도록 수정