### PR TITLE
[프로젝트] 정렬순서 - JNO역순, 타입별로 구분하여 반환

### DIFF
--- a/csm-api/handler/handler_project.go
+++ b/csm-api/handler/handler_project.go
@@ -369,6 +369,72 @@ func (h *HandlerProject) NonRegList(w http.ResponseWriter, r *http.Request) {
 	SuccessValuesResponse(ctx, w, values)
 }
 
+// func: 현장근태 사용되지 않은 프로젝트
+// @param
+// -
+func (h *HandlerProject) NonRegListByType(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	page := entity.Page{}
+	search := entity.NonUsedProject{}
+
+	pageNum := r.URL.Query().Get("page_num")
+	rowSize := r.URL.Query().Get("row_size")
+	order := r.URL.Query().Get("order")
+	rnumOrder := r.URL.Query().Get("rnum_order")
+	retrySearch := r.URL.Query().Get("retry_search")
+	jno := r.URL.Query().Get("jno")
+	jobNo := r.URL.Query().Get("job_no")
+	JobName := r.URL.Query().Get("job_name")
+	JobYear := r.URL.Query().Get("job_year")
+	JobSd := r.URL.Query().Get("job_sd")
+	JobEd := r.URL.Query().Get("job_ed")
+	UserName := r.URL.Query().Get("job_pm_nm")
+
+	typeValue := r.PathValue("type")
+	if typeValue == "" {
+		BadRequestResponse(ctx, w)
+		return
+	}
+
+	if pageNum == "" || rowSize == "" {
+		BadRequestResponse(ctx, w)
+		return
+	}
+
+	page.PageNum, _ = strconv.Atoi(pageNum)
+	page.RowSize, _ = strconv.Atoi(rowSize)
+	page.Order = order
+	page.RnumOrder = rnumOrder
+
+	search.Jno = utils.ParseNullInt(jno)
+	search.JobNo = utils.ParseNullString(jobNo)
+	search.JobName = utils.ParseNullString(JobName)
+	search.JobYear = utils.ParseNullInt(JobYear)
+	search.JobSd = utils.ParseNullString(JobSd)
+	search.JobEd = utils.ParseNullString(JobEd)
+	search.JobPmNm = utils.ParseNullString(UserName)
+
+	list, err := h.Service.GetNonUsedProjectListByType(ctx, page, search, retrySearch, typeValue)
+	if err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+
+	// 개수 조회
+	count, err := h.Service.GetNonUsedProjectCountByType(ctx, search, retrySearch, typeValue)
+	if err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+
+	values := struct {
+		List  entity.NonUsedProjects `json:"list"`
+		Count int                    `json:"count"`
+	}{List: *list, Count: count}
+	SuccessValuesResponse(ctx, w, values)
+}
+
 // func: 현장 프로젝트 추가
 // @param
 // -

--- a/csm-api/route/route_project.go
+++ b/csm-api/route/route_project.go
@@ -17,11 +17,6 @@ func ProjectRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 			SafeTDB:   safeDB,
 			Store:     r,
 			UserStore: r,
-			//ManHourService: &service.ServiceManHour{
-			//	SafeDB:  safeDB,
-			//	SafeTDB: safeDB,
-			//	Store:   r,
-			//},
 		},
 	}
 
@@ -32,6 +27,7 @@ func ProjectRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 	router.Get("/my-org/{uno}", projectHandler.MyOrgList)          // 본인이 속한 조직도의 프로젝트 조회
 	router.Get("/my-job_name/{uno}", projectHandler.MyJobNameList) // 본인이 속한 프로젝트 이름 목록
 	router.Get("/non-reg", projectHandler.NonRegList)              // 현장근태 사용되지 않은 프로젝트
+	router.Get("/non-reg/{type}", projectHandler.NonRegListByType) // 현장근태 사용되지 않은 프로젝트(Type별)
 	router.Get("/project-by-site", projectHandler.ProjectBySite)   // 현장별 프로젝트 조회
 	router.Post("/", projectHandler.Add)                           // 추가
 	router.Put("/default", projectHandler.ModifyDefault)           // 현장 기본 프로젝트 변경

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -53,6 +53,8 @@ type ProjectService interface {
 	GetProjectNmUnoList(ctx context.Context, uno int64, role string) (*entity.ProjectInfos, error)
 	GetNonUsedProjectList(ctx context.Context, page entity.Page, search entity.NonUsedProject, retry string) (*entity.NonUsedProjects, error)
 	GetNonUsedProjectCount(ctx context.Context, search entity.NonUsedProject, retry string) (int, error)
+	GetNonUsedProjectListByType(ctx context.Context, page entity.Page, search entity.NonUsedProject, retry string, typeString string) (*entity.NonUsedProjects, error)
+	GetNonUsedProjectCountByType(ctx context.Context, search entity.NonUsedProject, retry string, typeString string) (int, error)
 	GetProjectBySite(ctx context.Context, sno int64) (entity.ProjectInfos, error)
 	AddProject(ctx context.Context, project entity.ReqProject) error
 	ModifyDefaultProject(ctx context.Context, project entity.ReqProject) error

--- a/csm-api/service/service_project.go
+++ b/csm-api/service/service_project.go
@@ -285,6 +285,38 @@ func (s *ServiceProject) GetNonUsedProjectCount(ctx context.Context, search enti
 	return count, nil
 }
 
+// func: 현장근태 사용되지 않은 프로젝트(타입별)
+// @param
+// -
+func (s *ServiceProject) GetNonUsedProjectListByType(ctx context.Context, page entity.Page, search entity.NonUsedProject, retry string, typeString string) (*entity.NonUsedProjects, error) {
+	pageSql := entity.PageSql{}
+	pageSql, err := pageSql.OfPageSql(page)
+	if err != nil {
+		return nil, utils.CustomErrorf(err)
+	}
+
+	list, err := s.Store.GetNonUsedProjectListByType(ctx, s.SafeDB, pageSql, search, retry, typeString)
+
+	if err != nil {
+		return nil, utils.CustomErrorf(err)
+	}
+
+	return list, nil
+}
+
+// func: 현장근태 사용되지 않은 프로젝트 수(타입별)
+// @param
+// -
+func (s *ServiceProject) GetNonUsedProjectCountByType(ctx context.Context, search entity.NonUsedProject, retry string, typeString string) (int, error) {
+	count, err := s.Store.GetNonUsedProjectCountByType(ctx, s.SafeDB, search, retry, typeString)
+
+	if err != nil {
+		return 0, utils.CustomErrorf(err)
+	}
+
+	return count, nil
+}
+
 // 현장별 프로젝트 조회
 func (s *ServiceProject) GetProjectBySite(ctx context.Context, sno int64) (entity.ProjectInfos, error) {
 	projectInfos, err := s.Store.GetProjectBySite(ctx, s.SafeDB, sno)

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -61,6 +61,8 @@ type ProjectStore interface {
 	GetProjectNmUnoList(ctx context.Context, db Queryer, uno sql.NullInt64, role int) (*entity.ProjectInfos, error)
 	GetNonUsedProjectList(ctx context.Context, db Queryer, page entity.PageSql, search entity.NonUsedProject, retry string) (*entity.NonUsedProjects, error)
 	GetNonUsedProjectCount(ctx context.Context, db Queryer, search entity.NonUsedProject, retry string) (int, error)
+	GetNonUsedProjectListByType(ctx context.Context, db Queryer, page entity.PageSql, search entity.NonUsedProject, retry string, typeString string) (*entity.NonUsedProjects, error)
+	GetNonUsedProjectCountByType(ctx context.Context, db Queryer, search entity.NonUsedProject, retry string, typeString string) (int, error)
 	GetProjectBySite(ctx context.Context, db Queryer, sno int64) (entity.ProjectInfos, error)
 	AddProject(ctx context.Context, tx Execer, project entity.ReqProject) error
 	ModifyDefaultProject(ctx context.Context, tx Execer, project entity.ReqProject) error

--- a/csm-api/store/store_project.go
+++ b/csm-api/store/store_project.go
@@ -175,7 +175,7 @@ func (r *Repository) GetProjectList(ctx context.Context, db Queryer, sno int64, 
 			LEFT JOIN equip eq ON t1.SNO = eq.SNO  AND t1.JNO = eq.JNO
 			WHERE t1.SNO > 100
 			AND (:12 IS NULL OR t1.SNO = :13)
-			ORDER BY IS_DEFAULT DESC`
+			ORDER BY IS_DEFAULT DESC, JNO DESC`
 
 	if err := db.SelectContext(ctx, &projectInfos, sql,
 		snoParam, snoParam, targetDate, targetDate, targetDate,
@@ -353,7 +353,7 @@ func (r *Repository) GetProjectNmList(ctx context.Context, db Queryer) (*entity.
 			WHERE t1.sno > 100
 			AND t1.IS_USE = 'Y'
 			ORDER BY
-				t1.IS_DEFAULT DESC`
+				t1.IS_DEFAULT DESC, JNO DESC`
 	if err := db.SelectContext(ctx, &projectInfos, sql); err != nil {
 		return &projectInfos, utils.CustomErrorf(err)
 	}
@@ -387,7 +387,7 @@ func (r *Repository) GetUsedProjectList(ctx context.Context, db Queryer, pageSql
 	if pageSql.Order.Valid {
 		order = pageSql.Order.String
 	} else {
-		order = "JOB_NO ASC"
+		order = "JNO DESC, JOB_NO ASC"
 	}
 
 	query := fmt.Sprintf(`
@@ -767,7 +767,7 @@ func (r *Repository) GetNonUsedProjectList(ctx context.Context, db Queryer, page
 	if page.Order.Valid {
 		order = page.Order.String
 	} else {
-		order = `
+		order = `JNO DESC,
 				CASE 
 					WHEN t1.REG_DATE IS NULL THEN t1.MOD_DATE 
 					WHEN t1.MOD_DATE IS NULL THEN t1.REG_DATE 
@@ -865,7 +865,8 @@ func (r *Repository) GetProjectBySite(ctx context.Context, db Queryer, sno int64
 			T2.JOB_NAME	AS PROJECT_NM
 		FROM IRIS_SITE_JOB T1
 		LEFT JOIN SYS_JOB_INFO T2 ON T1.JNO = T2.JNO
-		WHERE T1.SNO = :1`
+		WHERE T1.SNO = :1
+		ORDER BY JNO DESC`
 
 	if err := db.SelectContext(ctx, &list, query, sno); err != nil {
 		return nil, utils.CustomErrorf(err)


### PR DESCRIPTION
1. 프로젝트 JNO 역순으로 정렬
2. 현장 추가 시 현장근태에 사용되지 않는 프로젝트들 중 T, C 등 타입별로 구분하여 반환