### PR TITLE
 트랜잭션 오류 및 오라클 프로세스 운영유저 root 실행 해결 그 외

### DIFF
--- a/csm-api/Dockerfile
+++ b/csm-api/Dockerfile
@@ -15,11 +15,25 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags prod -o app
 # 실행 환경 설정
 FROM base-dependencies
 
+# 빌드 시점에 사용할 고정 UID/GID를 인자로 받습니다 (기본값 101)
+ARG CIMAGE_UID=101
+ARG CIMAGE_GID=101
+
+# non-root 그룹 및 사용자 생성 (고정된 UID/GID 사용)
+RUN addgroup --system --gid ${CIMAGE_GID} cimage \
+ && adduser --system --uid ${CIMAGE_UID} --gid ${CIMAGE_GID} --disabled-password --gecos "" cimage
+
 # Go 애플리케이션 복사
 COPY --from=builder /app/app /app/
 
 # 작업 디렉토리 설정
 WORKDIR /app
+
+# 애플리케이션 소유권을 고정 UID/GID의 cimage 사용자로 변경
+RUN chown ${CIMAGE_UID}:${CIMAGE_GID} /app/app
+
+# non-root 사용자로 전환
+USER cimage
 
 # 실행 명령어
 CMD ["./app"]

--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -6,6 +6,7 @@ import (
 
 type Worker struct {
 	RowNum      null.Int    `json:"rnum" db:"RNUM"`
+	UserKey     null.String `json:"user_key" db:"USER_KEY"`
 	Sno         null.Int    `json:"sno" db:"SNO"` //현장 고유번호
 	SiteNm      null.String `json:"site_nm" db:"SITE_NM"`
 	Jno         null.Int    `json:"jno" db:"JNO"` //프로젝트 고유번호
@@ -29,8 +30,9 @@ type Workers []*Worker
 
 type WorkerDaily struct {
 	RowNum          null.Int    `json:"rnum" db:"RNUM"`
-	Sno             null.Int    `json:"sno" db:"SNO"`         //현장 고유번호
-	Jno             null.Int    `json:"jno" db:"JNO"`         //프로젝트 고유번호
+	Sno             null.Int    `json:"sno" db:"SNO"` //현장 고유번호
+	Jno             null.Int    `json:"jno" db:"JNO"` //프로젝트 고유번호
+	UserKey         null.String `json:"user_key" db:"USER_KEY"`
 	UserId          null.String `json:"user_id" db:"USER_ID"` //근로자 아이디
 	UserNm          null.String `json:"user_nm" db:"USER_NM"`
 	Department      null.String `json:"department" db:"DEPARTMENT"`

--- a/csm-api/enum/worker.go
+++ b/csm-api/enum/worker.go
@@ -1,0 +1,7 @@
+package enum
+
+type workerErr string
+
+const (
+	WORKER_T_A workerErr = "TOTAL_ADD_FAIL"
+)

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -139,7 +139,7 @@ type WorkerService interface {
 
 type WorkHourService interface {
 	ModifyWorkHour(ctx context.Context, user entity.Base) error
-	ModifyWorkHourByJno(ctx context.Context, jno int64, user entity.Base, ids []string) error
+	ModifyWorkHourByJno(ctx context.Context, jno int64, user entity.Base, uuids []string) error
 }
 
 type CompanyService interface {

--- a/csm-api/service/service_code.go
+++ b/csm-api/service/service_code.go
@@ -48,12 +48,15 @@ func (s *ServiceCode) GetCodeTree(ctx context.Context, pCode string) (*entity.Co
 // @param
 // -
 func (s *ServiceCode) MergeCode(ctx context.Context, code entity.Code) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.MergeCode(ctx, tx, code); err != nil {
 		return utils.CustomErrorf(err)
@@ -66,12 +69,15 @@ func (s *ServiceCode) MergeCode(ctx context.Context, code entity.Code) (err erro
 // @param
 // -
 func (s *ServiceCode) RemoveCode(ctx context.Context, idx int64) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.RemoveCode(ctx, tx, idx); err != nil {
 		return utils.CustomErrorf(err)
@@ -84,12 +90,15 @@ func (s *ServiceCode) RemoveCode(ctx context.Context, idx int64) (err error) {
 // @param
 // -
 func (s *ServiceCode) ModifySortNo(ctx context.Context, codeSorts entity.CodeSorts) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	for _, codeSort := range codeSorts {
 		if err = s.Store.ModifySortNo(ctx, tx, *codeSort); err != nil {

--- a/csm-api/service/service_compare.go
+++ b/csm-api/service/service_compare.go
@@ -252,12 +252,15 @@ func (s *ServiceCompare) GetCompareList(ctx context.Context, compare entity.Comp
 
 // 근로자 비교 반영
 func (s *ServiceCompare) ModifyWorkerCompareApply(ctx context.Context, workers entity.WorkerDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 근로자 정보: IRIS_WORKER_SET
 	// 선택한 프로젝트로 수정

--- a/csm-api/service/service_device.go
+++ b/csm-api/service/service_device.go
@@ -60,12 +60,15 @@ func (s *ServiceDevice) GetDeviceListCount(ctx context.Context, search entity.De
 // @param
 // - device entity.Device: SNO, DEVICE_SN, DEVICE_NM, ETC, IS_USE, REG_USER
 func (s *ServiceDevice) AddDevice(ctx context.Context, device entity.Device) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.AddDevice(ctx, tx, device); err != nil {
 		return utils.CustomErrorf(err)
@@ -77,12 +80,15 @@ func (s *ServiceDevice) AddDevice(ctx context.Context, device entity.Device) (er
 // @param
 // - device entity.DeviceSql: DNO, SNO, DEVICE_SN, DEVICE_NM, ETC, IS_USE, MOD_USER
 func (s *ServiceDevice) ModifyDevice(ctx context.Context, device entity.Device) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.ModifyDevice(ctx, tx, device); err != nil {
 		return utils.CustomErrorf(err)
@@ -94,12 +100,15 @@ func (s *ServiceDevice) ModifyDevice(ctx context.Context, device entity.Device) 
 // @param
 // - dno int64: 홍채인식기 고유번호
 func (s *ServiceDevice) RemoveDevice(ctx context.Context, dno int64) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	var dnoSql sql.NullInt64
 	if dno != 0 {

--- a/csm-api/service/service_equip.go
+++ b/csm-api/service/service_equip.go
@@ -23,12 +23,15 @@ func (s *ServiceEquip) GetEquipList(ctx context.Context) (entity.EquipTemps, err
 }
 
 func (s *ServiceEquip) MergeEquipCnt(ctx context.Context, equips entity.EquipTemps) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.MergeEquipCnt(ctx, tx, equips); err != nil {
 		return utils.CustomErrorf(err)

--- a/csm-api/service/service_notice.go
+++ b/csm-api/service/service_notice.go
@@ -91,12 +91,15 @@ func (s *ServiceNotice) GetNoticeListCount(ctx context.Context, search entity.No
 // @param
 // - notice entity.Notice: JNO, TITLE, CONTENT, SHOW_YN, PERIOD_CODE, REG_UNO, REG_USER
 func (s *ServiceNotice) AddNotice(ctx context.Context, notice entity.Notice) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.AddNotice(ctx, tx, notice); err != nil {
 		return fmt.Errorf("service_notice/AddNotice err : %w", err)
@@ -109,12 +112,15 @@ func (s *ServiceNotice) AddNotice(ctx context.Context, notice entity.Notice) (er
 // @param
 // -notice entity.Notice: IDX, JNO, TITLE, CONTENT, SHOW_YN, MOD_UNO, MOD_USER
 func (s *ServiceNotice) ModifyNotice(ctx context.Context, notice entity.Notice) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.ModifyNotice(ctx, tx, notice); err != nil {
 		return utils.CustomErrorf(err)
@@ -127,12 +133,15 @@ func (s *ServiceNotice) ModifyNotice(ctx context.Context, notice entity.Notice) 
 // @param
 // - IDX: 공지사항 인덱스
 func (s *ServiceNotice) RemoveNotice(ctx context.Context, idx int64) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.RemoveNotice(ctx, tx, idx); err != nil {
 		return utils.CustomErrorf(err)

--- a/csm-api/service/service_project.go
+++ b/csm-api/service/service_project.go
@@ -330,12 +330,15 @@ func (s *ServiceProject) GetProjectBySite(ctx context.Context, sno int64) (entit
 // @param
 // -
 func (s *ServiceProject) AddProject(ctx context.Context, project entity.ReqProject) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.AddProject(ctx, tx, project)
 	if err != nil {
@@ -348,12 +351,15 @@ func (s *ServiceProject) AddProject(ctx context.Context, project entity.ReqProje
 // @param
 // -
 func (s *ServiceProject) ModifyDefaultProject(ctx context.Context, project entity.ReqProject) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.ModifyDefaultProject(ctx, tx, project)
 	if err != nil {
@@ -366,12 +372,15 @@ func (s *ServiceProject) ModifyDefaultProject(ctx context.Context, project entit
 // @param
 // -
 func (s *ServiceProject) ModifyUseProject(ctx context.Context, project entity.ReqProject) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.ModifyUseProject(ctx, tx, project)
 	if err != nil {
@@ -384,12 +393,15 @@ func (s *ServiceProject) ModifyUseProject(ctx context.Context, project entity.Re
 // @param
 // -
 func (s *ServiceProject) RemoveProject(ctx context.Context, sno int64, jno int64) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.RemoveProject(ctx, tx, sno, jno)
 	if err != nil {

--- a/csm-api/service/service_project_daily.go
+++ b/csm-api/service/service_project_daily.go
@@ -25,12 +25,15 @@ func (s *ServiceProjectDaily) GetDailyJobList(ctx context.Context, jno int64, ta
 
 // 작업내용 추가
 func (s *ServiceProjectDaily) AddDailyJob(ctx context.Context, project entity.ProjectDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.AddDailyJob(ctx, tx, project); err != nil {
 		return utils.CustomErrorf(err)
@@ -40,12 +43,15 @@ func (s *ServiceProjectDaily) AddDailyJob(ctx context.Context, project entity.Pr
 
 // 작업내용 수정
 func (s *ServiceProjectDaily) ModifyDailyJob(ctx context.Context, project entity.ProjectDaily) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.ModifyDailyJob(ctx, tx, project); err != nil {
 		return utils.CustomErrorf(err)
@@ -55,12 +61,15 @@ func (s *ServiceProjectDaily) ModifyDailyJob(ctx context.Context, project entity
 
 // 작업내용 삭제
 func (s *ServiceProjectDaily) RemoveDailyJob(ctx context.Context, idx int64) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.RemoveDailyJob(ctx, tx, idx); err != nil {
 		return utils.CustomErrorf(err)

--- a/csm-api/service/service_project_setting.go
+++ b/csm-api/service/service_project_setting.go
@@ -36,12 +36,15 @@ func (s *ServiceProjectSetting) GetManHourList(ctx context.Context, jno int64) (
 // @param
 // - manHours: 공수 정보 배열
 func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *entity.ManHours) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	jno := (*manHours)[0].Jno.Int64
 	user := (*manHours)[0].Base
@@ -104,12 +107,15 @@ func (s *ServiceProjectSetting) MergeManHours(ctx context.Context, manHours *ent
 // @param
 // - ProjectSetting
 func (s *ServiceProjectSetting) MergeProjectSetting(ctx context.Context, project entity.ProjectSetting) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if !project.Message.Valid {
 		return
@@ -216,12 +222,15 @@ func (s *ServiceProjectSetting) GetProjectSetting(ctx context.Context, jno int64
 // @param
 // - mhno: 공수pk
 func (s *ServiceProjectSetting) DeleteManHour(ctx context.Context, mhno int64, manhour entity.ManHour) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 공수 삭제
 	if err = s.Store.DeleteManHour(ctx, tx, mhno); err != nil {
@@ -244,12 +253,15 @@ func (s *ServiceProjectSetting) DeleteManHour(ctx context.Context, mhno int64, m
 
 // 공수 추가(삭제 없이 추가만)
 func (s *ServiceProjectSetting) AddManHour(ctx context.Context, manhour entity.ManHour) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.AddManHour(ctx, tx, manhour); err != nil {
 		return utils.CustomErrorf(err)

--- a/csm-api/service/service_schedule.go
+++ b/csm-api/service/service_schedule.go
@@ -30,12 +30,15 @@ func (s *ServiceSchedule) GetRestScheduleList(ctx context.Context, jno int64, ye
 // @param
 // -
 func (s *ServiceSchedule) AddRestSchedule(ctx context.Context, schedule entity.RestSchedules) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.AddRestSchedule(ctx, tx, schedule)
 	if err != nil {
@@ -49,12 +52,15 @@ func (s *ServiceSchedule) AddRestSchedule(ctx context.Context, schedule entity.R
 // @param
 // -
 func (s *ServiceSchedule) ModifyRestSchedule(ctx context.Context, schedule entity.RestSchedule) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.ModifyRestSchedule(ctx, tx, schedule)
 	if err != nil {
@@ -68,12 +74,15 @@ func (s *ServiceSchedule) ModifyRestSchedule(ctx context.Context, schedule entit
 // @param
 // -
 func (s *ServiceSchedule) RemoveRestSchedule(ctx context.Context, cno int64) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.RemoveRestSchedule(ctx, tx, cno)
 	if err != nil {

--- a/csm-api/service/service_site.go
+++ b/csm-api/service/service_site.go
@@ -188,12 +188,15 @@ func (s *ServiceSite) GetSiteStatsList(ctx context.Context, targetDate time.Time
 // @param
 // -
 func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if site.Sno.Int64 == 0 {
 		return utils.CustomErrorf(fmt.Errorf("sno parameter is missing"))
@@ -271,12 +274,15 @@ func (s *ServiceSite) ModifySite(ctx context.Context, site entity.Site) (err err
 // @param
 // -
 func (s *ServiceSite) AddSite(ctx context.Context, jno int64, user entity.User) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.AddSite(ctx, s.SafeDB, tx, jno, user)
 	if err != nil {
@@ -290,12 +296,15 @@ func (s *ServiceSite) AddSite(ctx context.Context, jno int64, user entity.User) 
 // @param
 // -
 func (s *ServiceSite) ModifySiteIsNonUse(ctx context.Context, site entity.ReqSite) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 현장
 	if err = s.Store.ModifySiteIsNonUse(ctx, tx, site); err != nil {
@@ -323,12 +332,15 @@ func (s *ServiceSite) ModifySiteIsNonUse(ctx context.Context, site entity.ReqSit
 // @param
 // -
 func (s *ServiceSite) ModifySiteIsUse(ctx context.Context, site entity.ReqSite) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 현장
 	if err = s.Store.ModifySiteIsUse(ctx, tx, site); err != nil {
@@ -356,12 +368,15 @@ func (s *ServiceSite) ModifySiteIsUse(ctx context.Context, site entity.ReqSite) 
 // @param
 // -
 func (s *ServiceSite) SettingWorkRate(ctx context.Context, targetDate time.Time) (count int64, err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return 0, utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	count, err = s.Store.SettingWorkRate(ctx, tx, targetDate)
 	if err != nil {
@@ -373,12 +388,15 @@ func (s *ServiceSite) SettingWorkRate(ctx context.Context, targetDate time.Time)
 
 // 공정률 수정
 func (s *ServiceSite) ModifyWorkRate(ctx context.Context, workRate entity.SiteWorkRate) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.ModifyWorkRate(ctx, tx, workRate)
 	if err != nil {

--- a/csm-api/service/service_site_date.go
+++ b/csm-api/service/service_site_date.go
@@ -32,12 +32,15 @@ func (s *ServiceSiteDate) GetSiteDateData(ctx context.Context, sno int64) (*enti
 // - sno: 현장고유번호
 // - siteDate: 현장 시간 (opening_date, closing_plan_date, closing_forecast_date, closing_actual_date)
 func (s *ServiceSiteDate) ModifySiteDate(ctx context.Context, sno int64, siteDate entity.SiteDate) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.TDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.TDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err := s.Store.ModifySiteDate(ctx, tx, sno, siteDate); err != nil {
 		return utils.CustomErrorf(err)

--- a/csm-api/service/service_site_pos.go
+++ b/csm-api/service/service_site_pos.go
@@ -54,12 +54,15 @@ func (s *ServiceSitePos) GetSitePosData(ctx context.Context, sno int64) (*entity
 //     ROAD_ADDRESS_NAME_DEPTH1, ROAD_ADDRESS_NAME_DEPTH2, ROAD_ADDRESS_NAME_DEPTH3, ROAD_ADDRESS_NAME_DEPTH4, ROAD_ADDRESS_NAME_DEPTH5,
 //     ROAD_ADDRESS, ZONE_CODE, BUILDING_NAME)
 func (s *ServiceSitePos) ModifySitePos(ctx context.Context, sno int64, sitePos entity.SitePos) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.TDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.TDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err := s.Store.ModifySitePosData(ctx, tx, sno, sitePos); err != nil {
 		return utils.CustomErrorf(err)

--- a/csm-api/service/service_user_role.go
+++ b/csm-api/service/service_user_role.go
@@ -36,12 +36,15 @@ func (s *ServiceUserRole) GetUserRoleListByCodeAndJno(ctx context.Context, code 
 
 // 사용자 권한 추가
 func (s *ServiceUserRole) AddUserRole(ctx context.Context, userRoles []entity.UserRoleMap) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.AddUserRole(ctx, tx, userRoles); err != nil {
 		err = utils.CustomErrorf(err)
@@ -51,12 +54,15 @@ func (s *ServiceUserRole) AddUserRole(ctx context.Context, userRoles []entity.Us
 
 // 사용자 권한 삭제
 func (s *ServiceUserRole) RemoveUserRole(ctx context.Context, userRoles []entity.UserRoleMap) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.RemoveUserRole(ctx, tx, userRoles); err != nil {
 		err = utils.CustomErrorf(err)

--- a/csm-api/service/service_work_hour.go
+++ b/csm-api/service/service_work_hour.go
@@ -14,16 +14,19 @@ type ServiceWorkHour struct {
 	Store   store.WorkHourStore
 }
 
-// 특정 프로젝트 및 근로자의 공수 계산: jno는 필수, ids는 없으면 jno의 모든 근로자 계산 있으면 해당 id의 근로자만 계산
-func (s *ServiceWorkHour) ModifyWorkHourByJno(ctx context.Context, jno int64, user entity.Base, ids []string) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+// 특정 프로젝트 및 근로자의 공수 계산: jno는 필수, uuids는 없으면 jno의 모든 근로자 계산 있으면 해당 id의 근로자만 계산
+func (s *ServiceWorkHour) ModifyWorkHourByJno(ctx context.Context, jno int64, user entity.Base, uuids []string) (err error) {
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
-	err = s.Store.ModifyWorkHourByJno(ctx, tx, jno, user, ids)
+	err = s.Store.ModifyWorkHourByJno(ctx, tx, jno, user, uuids)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
@@ -32,12 +35,15 @@ func (s *ServiceWorkHour) ModifyWorkHourByJno(ctx context.Context, jno int64, us
 
 // 출퇴근이 둘다 있는 모든 근로자의 공수 계산
 func (s *ServiceWorkHour) ModifyWorkHour(ctx context.Context, user entity.Base) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.ModifyWorkHour(ctx, tx, user)
 	if err != nil {

--- a/csm-api/service/service_worker.go
+++ b/csm-api/service/service_worker.go
@@ -101,12 +101,15 @@ func (s *ServiceWorker) GetWorkerDepartList(ctx context.Context, jno int64) ([]s
 // @param
 // -
 func (s *ServiceWorker) AddWorker(ctx context.Context, worker entity.Worker) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.AddWorker(ctx, tx, worker)
 	if err != nil {
@@ -119,12 +122,15 @@ func (s *ServiceWorker) AddWorker(ctx context.Context, worker entity.Worker) (er
 // @param
 // -
 func (s *ServiceWorker) ModifyWorker(ctx context.Context, worker entity.Worker) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	err = s.Store.ModifyWorker(ctx, tx, worker)
 	if err != nil {
@@ -169,12 +175,15 @@ func (s *ServiceWorker) GetWorkerSiteBaseCount(ctx context.Context, search entit
 // @param
 // -
 func (s *ServiceWorker) MergeSiteBaseWorker(ctx context.Context, workers entity.WorkerDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 추가/수정
 	if err = s.Store.MergeSiteBaseWorker(ctx, tx, workers); err != nil {
@@ -193,12 +202,15 @@ func (s *ServiceWorker) MergeSiteBaseWorker(ctx context.Context, workers entity.
 // @param
 // -
 func (s *ServiceWorker) ModifyWorkerDeadline(ctx context.Context, workers entity.WorkerDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 마감처리
 	if err = s.Store.ModifyWorkerDeadline(ctx, tx, workers); err != nil {
@@ -216,12 +228,15 @@ func (s *ServiceWorker) ModifyWorkerDeadline(ctx context.Context, workers entity
 // @param
 // -
 func (s *ServiceWorker) ModifyWorkerProject(ctx context.Context, workers entity.WorkerDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 전체 근로자 프로젝트 변경
 	if err = s.Store.ModifyWorkerDefaultProject(ctx, tx, workers); err != nil {
@@ -245,12 +260,15 @@ func (s *ServiceWorker) ModifyWorkerProject(ctx context.Context, workers entity.
 // @param
 // -
 func (s *ServiceWorker) ModifyWorkerDeadlineInit(ctx context.Context) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	if err = s.Store.ModifyWorkerDeadlineInit(ctx, tx); err != nil {
 		return utils.CustomErrorf(err)
@@ -262,12 +280,15 @@ func (s *ServiceWorker) ModifyWorkerDeadlineInit(ctx context.Context) (err error
 // @param
 // -
 func (s *ServiceWorker) ModifyWorkerOverTime(ctx context.Context) (count int, err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return 0, utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 철야 근로자 존재 여부 확인
 	workerOverTimes := &entity.WorkerOverTimes{}
@@ -294,12 +315,15 @@ func (s *ServiceWorker) ModifyWorkerOverTime(ctx context.Context) (count int, er
 
 // 현장 근로자 삭제
 func (s *ServiceWorker) RemoveSiteBaseWorkers(ctx context.Context, workers entity.WorkerDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 현장 근로자 삭제
 	if err = s.Store.RemoveSiteBaseWorkers(ctx, tx, workers); err != nil {
@@ -316,12 +340,15 @@ func (s *ServiceWorker) RemoveSiteBaseWorkers(ctx context.Context, workers entit
 
 // 마감 취소
 func (s *ServiceWorker) ModifyDeadlineCancel(ctx context.Context, workers entity.WorkerDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 마감 취소
 	if err = s.Store.ModifyDeadlineCancel(ctx, tx, workers); err != nil {
@@ -347,12 +374,15 @@ func (s *ServiceWorker) GetDailyWorkersByJnoAndDate(ctx context.Context, param e
 
 // 현장근로자 일괄 공수 변경
 func (s *ServiceWorker) ModifyWorkHours(ctx context.Context, workers entity.WorkerDailys) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	tx, cleanup, err := txutil.BeginTxWithCleanMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
 	}
 
-	defer txutil.DeferTx(tx, &err)
+	defer func() {
+		txutil.DeferTx(tx, &err)
+		cleanup()
+	}()
 
 	// 공수 변경
 	if err = s.Store.ModifyWorkHours(ctx, tx, workers); err != nil {

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -160,7 +160,7 @@ type WorkerStore interface {
 
 type WorkHourStore interface {
 	ModifyWorkHour(ctx context.Context, tx Execer, user entity.Base) error
-	ModifyWorkHourByJno(ctx context.Context, tx Execer, jno int64, user entity.Base, ids []string) error
+	ModifyWorkHourByJno(ctx context.Context, tx Execer, jno int64, user entity.Base, uuids []string) error
 }
 
 type CompanyStore interface {

--- a/csm-api/store/store_project.go
+++ b/csm-api/store/store_project.go
@@ -31,13 +31,13 @@ func (r *Repository) GetProjectList(ctx context.Context, db Queryer, sno int64, 
 				SELECT
 					t1.SNO,
 					t1.JNO,
-					t1.USER_ID,
+					t2.USER_ID,
 					NVL(t2.USER_NM, ' ') AS USER_NM,
 					TO_CHAR(t1.RECORD_DATE, 'YYYY-MM-DD') AS RECORD_DATE,
 					NVL(t2.DEPARTMENT, ' ') AS DEPARTMENT,
 					t2.WORKER_TYPE
 				FROM IRIS_WORKER_DAILY_SET t1
-				LEFT JOIN IRIS_WORKER_SET t2 ON t1.SNO = t2.SNO AND t1.JNO = t2.JNO AND t1.USER_ID = t2.USER_ID
+				LEFT JOIN IRIS_WORKER_SET t2 ON t1.SNO = t2.SNO AND t1.JNO = t2.JNO AND t1.USER_KEY = t2.USER_KEY
 				WHERE t1.SNO > 100
 				AND (:1 IS NULL OR t1.SNO = :2) AND t1.RECORD_DATE < :3
 			),
@@ -199,13 +199,13 @@ func (r *Repository) GetProjectWorkerCountList(ctx context.Context, db Queryer, 
 					SELECT
 						t1.SNO,
 						t1.JNO,
-						t1.USER_ID,
+						t2.USER_ID,
 						NVL(t2.USER_NM, ' ') AS USER_NM,
 						TO_CHAR(t1.RECORD_DATE, 'YYYY-MM-DD') AS RECORD_DATE,
 						NVL(t2.DEPARTMENT, ' ') AS DEPARTMENT,
 						t2.WORKER_TYPE
 					FROM IRIS_WORKER_DAILY_SET t1
-					LEFT JOIN IRIS_WORKER_SET t2 ON t1.SNO = t2.SNO AND t1.JNO = t2.JNO AND t1.USER_ID = t2.USER_ID
+					LEFT JOIN IRIS_WORKER_SET t2 ON t1.SNO = t2.SNO AND t1.JNO = t2.JNO AND t1.USER_KEY = t2.USER_KEY
 					WHERE t1.SNO > 100
 				),
 				worker_counts AS (
@@ -283,7 +283,7 @@ func (r *Repository) GetProjectSafeWorkerCountList(ctx context.Context, db Query
 				WITH htenc_cnt AS (
 					SELECT T1.SNO, T1.JNO, T2.USER_NM
 					FROM IRIS_WORKER_DAILY_SET t1
-					LEFT JOIN IRIS_WORKER_SET t2 ON t1.SNO = t2.SNO AND t1.JNO = t2.JNO AND t1.USER_ID = t2.USER_ID
+					LEFT JOIN IRIS_WORKER_SET t2 ON t1.SNO = t2.SNO AND t1.JNO = t2.JNO AND t1.USER_KEY = t2.USER_KEY
 					WHERE TO_CHAR(T1.RECORD_DATE, 'YYYY-MM-DD') = TO_CHAR(:1, 'YYYY-MM-DD')
 					AND (
 						INSTR(T2.DEPARTMENT, '하이테크') > 0 

--- a/csm-api/store/store_work_hour.go
+++ b/csm-api/store/store_work_hour.go
@@ -9,7 +9,7 @@ import (
 )
 
 // 마감처리가 안된 특정프로젝트의 근로자의 공수 계산: jno는 필수, ids는 없으면 jno의 모든 근로자 계산 있으면 해당 id의 근로자만 계산
-func (r *Repository) ModifyWorkHourByJno(ctx context.Context, tx Execer, jno int64, user entity.Base, ids []string) error {
+func (r *Repository) ModifyWorkHourByJno(ctx context.Context, tx Execer, jno int64, user entity.Base, uuids []string) error {
 	var (
 		query strings.Builder
 		args  []interface{}
@@ -77,9 +77,9 @@ func (r *Repository) ModifyWorkHourByJno(ctx context.Context, tx Execer, jno int
 					AND T1.JNO = :1
 					AND T1.IS_DEADLINE = 'N'`)
 
-	if len(ids) > 0 {
-		query.WriteString("\nAND T1.USER_ID IN (")
-		for i, id := range ids {
+	if len(uuids) > 0 {
+		query.WriteString("\nAND T1.USER_KEY IN (")
+		for i, id := range uuids {
 			if i > 0 {
 				query.WriteString(", ")
 			}
@@ -131,7 +131,7 @@ func (r *Repository) ModifyWorkHour(ctx context.Context, tx Execer, user entity.
 				SELECT 
 					T1.ROWID AS W_ROWID,
 					T1.JNO,
-					T1.USER_ID,
+					--T1.USER_ID,
 					T1.RECORD_DATE,
 					T1.IN_RECOG_TIME,
 					T1.OUT_RECOG_TIME,

--- a/csm-api/txutil/tx.go
+++ b/csm-api/txutil/tx.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/jmoiron/sqlx"
 )
 
 func DeferTx(tx *sql.Tx, err *error) {
@@ -31,23 +32,60 @@ func DeferTx(tx *sql.Tx, err *error) {
 	}
 }
 
-func BeginTxWithMode(ctx context.Context, db store.Beginner, readOnly bool) (*sql.Tx, error) {
-	opts := &sql.TxOptions{
-		ReadOnly: false,
+func DeferTxx(tx *sqlx.Tx, err *error) {
+	if tx == nil {
+		return
 	}
 
-	conn, err := db.Conn(ctx)
-	tx, err := conn.BeginTx(ctx, opts)
+	if r := recover(); r != nil {
+		_ = tx.Rollback()
+		*err = utils.CustomMessageErrorfDepth(2, "panic", fmt.Errorf("%v", r))
+		return
+	}
+
+	if *err != nil {
+		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
+			*err = utils.CustomMessageErrorfDepth(2, "rollback", rollbackErr)
+		}
+	} else {
+		if commitErr := tx.Commit(); commitErr != nil && !errors.Is(commitErr, sql.ErrTxDone) {
+			*err = utils.CustomMessageErrorfDepth(2, "commit", commitErr)
+		}
+	}
+}
+
+func BeginTxWithCleanMode(ctx context.Context, db store.Beginner, readOnly bool) (tx *sql.Tx, cleanup func(), err error) {
+	//conn, err := db.Conn(ctx)
+	//if err != nil {
+	//	return nil, nil, utils.CustomMessageErrorfDepth(2, "db.Conn", err)
+	//}
+	//
+	//tx, err = conn.BeginTx(ctx, &sql.TxOptions{ReadOnly: readOnly})
+	tx, err = db.BeginTx(ctx, &sql.TxOptions{ReadOnly: readOnly})
 	if err != nil {
-		return nil, utils.CustomMessageErrorfDepth(2, "begin tx", err)
+		orig := err
+		//_ = conn.Close()
+		return nil, nil, utils.CustomMessageErrorfDepth(2, "begin tx", orig)
 	}
 
 	if readOnly {
-		if _, err = tx.Exec("SET TRANSACTION READ ONLY"); err != nil {
+		if _, e := tx.Exec("SET TRANSACTION READ ONLY"); e != nil {
 			_ = tx.Rollback()
-			return nil, utils.CustomMessageErrorfDepth(2, "set transaction", err)
+			orig := e
+			//_ = conn.Close()
+			return nil, nil, utils.CustomMessageErrorfDepth(2, "set transaction", orig)
 		}
 	}
 
-	return tx, nil
+	cleanup = func() {
+		//if closeErr := conn.Close(); closeErr != nil {
+		//	if err != nil {
+		//		err = fmt.Errorf("%v; cleanup conn.Close: %w", err, closeErr)
+		//	} else {
+		//		err = utils.CustomMessageErrorfDepth(2, "cleanup conn.Close", closeErr)
+		//	}
+		//}
+	}
+
+	return
 }


### PR DESCRIPTION
1. 트랜잭션을 실행하게 되면 ORA-01453 `SET TRANSACTION must be first statement` 가 나오는 문제 : Go 표준 database/sql 풀에서 재사용된 커넥션을 꺼낼 때 이전 세션 상태(ALTER SESSION이나 이전 트랜잭션 모드)가 그대로 남아 있어서 `SET TRANSACTION must be first statement`가 발생함. 다른 언어의 라이브러리는 대부분 풀 자체에서 `ALTER SESSION RESET` 또는 `SET TRANSACTION …`을 자동 실행해 줘서 문제가 없지만 Go의 표준 라이브러리는 지원을 하지 않았었음.
- OCI Session Pool 사용하여 세션을 꺼낼 때마다 내부적으로 상태를 초기화하게 함
- Go에서의 풀을 비활성화하여 재사용 세션을 간섭 못하게 함

2. 운영서버에서 오라클 커넥션시 root로 실행 : Docker 컨테이너를 기본 root 계정으로 실행하면서 오라클 v$session.OSUSER 컬럼에 항상 ‘root’가 기록되었음.
- Dockerfile에 addgroup/adduser(--system)으로 cimage(non-root) 계정 추가
- USER cimage 지시자로 컨테이너 런타임 유저 전환
- 호스트 볼륨(/tmp/data/csm) 소유권을 cimage(uid/gid)로 chown하여 로그 쓰기 권한 확보

3. IRIS_WORKER_SER, IRIS_WORKER_DAILY_SET 테이블에 USER_KEY 추가로 인한 쿼리 수정