### PR TITLE
근로자 홍채인식기 데이터 저장 및 로그 설정

### DIFF
--- a/csm-api/config/config.go
+++ b/csm-api/config/config.go
@@ -6,13 +6,14 @@ import (
 )
 
 type Config struct {
-	Env        string `env:"ENV" envDefault:"local"`
-	Port       int    `env:"PORT" envDefault:"8082"`
-	Domain     string `env:"DOMAIN" envDefault:"localhost"`
-	UploadPath string `env:"UPLOAD_PATH" envDefault:"uploads"`
-	LogPath    string `env:"LOG_PATH" envDefault:"logs"`
-	ErrLogPath string `env:"ERR_LOG_PATH" envDefault:"logs/error"`
-	ExcelPath  string `env:"EXCEL_PATH" envDefault:"resources/excel"`
+	Env            string `env:"ENV" envDefault:"local"`
+	Port           int    `env:"PORT" envDefault:"8082"`
+	Domain         string `env:"DOMAIN" envDefault:"localhost"`
+	UploadPath     string `env:"UPLOAD_PATH" envDefault:"uploads"`
+	LogPath        string `env:"LOG_PATH" envDefault:"logs"`
+	ErrLogPath     string `env:"ERR_LOG_PATH" envDefault:"logs/error"`
+	ExcelPath      string `env:"EXCEL_PATH" envDefault:"resources/excel"`
+	ConsoleLogPath string `env:"CONSOLE_LOG_PATH" envDefault:"logs/console"`
 }
 
 // caarlos0/env 패키지를 사용하여 struct의 envDefault값을 환경변수로 넘겨준다.

--- a/csm-api/config/config_prod.go
+++ b/csm-api/config/config_prod.go
@@ -27,22 +27,27 @@ func init() {
 		log.Fatalf("Failed to set PORT: %v", err)
 	}
 
-	err = os.Setenv("UPLOAD_PATH", "/tmp/data/csm/uploads")
+	err = os.Setenv("UPLOAD_PATH", "/var/csm/uploads")
 	if err != nil {
 		log.Fatalf("Failed to set UPLOAD_PATH: %v", err)
 	}
 
-	err = os.Setenv("LOG_PATH", "/tmp/data/csm/logs")
+	err = os.Setenv("LOG_PATH", "/var/csm/logs")
 	if err != nil {
 		log.Fatalf("Failed to set LOG_PATH: %v", err)
 	}
 
-	err = os.Setenv("ERR_LOG_PATH", "/tmp/data/csm/logs/error")
+	err = os.Setenv("ERR_LOG_PATH", "/var/csm/logs/error")
 	if err != nil {
 		log.Fatalf("Failed to set LOG_PATH: %v", err)
 	}
 
-	err = os.Setenv("EXCEL_PATH", "/tmp/data/csm/resources/excel")
+	err = os.Setenv("EXCEL_PATH", "/var/csm/resources/excel")
+	if err != nil {
+		log.Fatalf("Failed to set EXCEL_PATH: %v", err)
+	}
+
+	err = os.Setenv("CONSOLE_LOG_PATH", "/var/log/csm")
 	if err != nil {
 		log.Fatalf("Failed to set EXCEL_PATH: %v", err)
 	}

--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -6,6 +6,7 @@ import (
 
 type Worker struct {
 	RowNum      null.Int    `json:"rnum" db:"RNUM"`
+	IrisNo      null.Int    `json:"iris_no" db:"IRIS_NO"`
 	UserKey     null.String `json:"user_key" db:"USER_KEY"`
 	Sno         null.Int    `json:"sno" db:"SNO"` //현장 고유번호
 	SiteNm      null.String `json:"site_nm" db:"SITE_NM"`
@@ -30,6 +31,7 @@ type Workers []*Worker
 
 type WorkerDaily struct {
 	RowNum          null.Int    `json:"rnum" db:"RNUM"`
+	IrisNo          null.Int    `json:"iris_no" db:"IRIS_NO"`
 	Sno             null.Int    `json:"sno" db:"SNO"` //현장 고유번호
 	Jno             null.Int    `json:"jno" db:"JNO"` //프로젝트 고유번호
 	UserKey         null.String `json:"user_key" db:"USER_KEY"`

--- a/csm-api/init.go
+++ b/csm-api/init.go
@@ -61,6 +61,7 @@ func (i *Init) RunInitializations(ctx context.Context) (err error) {
 
 	eg.Go(func() error {
 		// 현장 근로자 공수계산 (당일 이전 날짜 중에서 출퇴퇴근을 데이터가 모드 있는 근로자만 처리)
+		log.Println("[init] ModifyWorkHour start")
 		user := entity.Base{
 			ModUser: utils.ParseNullString("SYSTEM_INIT"),
 		}
@@ -68,6 +69,26 @@ func (i *Init) RunInitializations(ctx context.Context) (err error) {
 			return entity.WriteErrorLog(ctx, utils.CustomErrorf(initErr))
 		}
 		log.Println("[init] ModifyWorkHour completed")
+		return nil
+	})
+
+	eg.Go(func() error {
+		// 홍채인식기 전체근로자 반영
+		log.Println("[init] MergeRecdWorker start")
+		if initErr := i.WorkerService.MergeRecdWorker(ctx); initErr != nil {
+			return entity.WriteErrorLog(ctx, utils.CustomErrorf(initErr))
+		}
+		log.Println("[init] MergeRecdWorker completed")
+		return nil
+	})
+
+	eg.Go(func() error {
+		// 홍채인식기 현장근로자 반영
+		log.Println("[init] MergeRecdDailyWorker start")
+		if initErr := i.WorkerService.MergeRecdDailyWorker(ctx); initErr != nil {
+			return entity.WriteErrorLog(ctx, utils.CustomErrorf(initErr))
+		}
+		log.Println("[init] MergeRecdDailyWorker completed")
 		return nil
 	})
 

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -31,11 +31,16 @@ func newMux(ctx context.Context, safeDb *sqlx.DB, timesheetDb *sqlx.DB) (http.Ha
 	mux := chi.NewRouter()
 
 	// CORS 미들웨어 설정
-	c := cors.New(cors.Options{
-		AllowedOrigins:   []string{"http://localhost:3002", "http://127.0.0.1:3002", "http://61.41.17.36", "http://csm.htenc.co.kr"}, // 허용할 도메인
-		AllowCredentials: true,                                                                                                       // 쿠키 허용
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},                                                        // 허용할 메서드
-		AllowedHeaders:   []string{"Content-Type", "Authorization"},                                                                  // 허용할 헤더
+	c := cors.New(cors.Options{ // 허용할 도메인
+		AllowedOrigins: []string{
+			"http://localhost:3002",
+			"http://127.0.0.1:3002",
+			"http://61.41.17.36",
+			"http://csm.htenc.co.kr",
+		},
+		AllowCredentials: true,                                                // 쿠키 허용
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"}, // 허용할 메서드
+		AllowedHeaders:   []string{"Content-Type", "Authorization"},           // 허용할 헤더
 	})
 	r := store.Repository{Clocker: clock.RealClock{}}
 

--- a/csm-api/server.go
+++ b/csm-api/server.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"csm-api/utils"
+	"errors"
 	"golang.org/x/sync/errgroup"
 	"log"
 	"net"
@@ -21,8 +22,8 @@ type Server struct {
 func (s *Server) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		log.Println("HTTP server starting...")
-		if err := s.srv.Serve(s.l); err != nil && err != http.ErrServerClosed {
+		log.Println("HTTP server start")
+		if err := s.srv.Serve(s.l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("failed to close: %+v", err)
 			return utils.CustomErrorf(err)
 		}

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -135,6 +135,8 @@ type WorkerService interface {
 	ModifyDeadlineCancel(ctx context.Context, workers entity.WorkerDailys) error
 	GetDailyWorkersByJnoAndDate(ctx context.Context, param entity.RecordDailyWorkerReq) ([]entity.RecordDailyWorkerRes, error)
 	ModifyWorkHours(ctx context.Context, workers entity.WorkerDailys) error
+	MergeRecdWorker(ctx context.Context) error
+	MergeRecdDailyWorker(ctx context.Context) error
 }
 
 type WorkHourService interface {

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -156,6 +156,12 @@ type WorkerStore interface {
 	AddDailyWorkers(ctx context.Context, db Queryer, tx Execer, workers []entity.WorkerDaily) (entity.WorkerDailys, error)
 	GetDailyWorkersByJnoAndDate(ctx context.Context, db Queryer, param entity.RecordDailyWorkerReq) ([]entity.RecordDailyWorkerRes, error)
 	ModifyWorkHours(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	GetRecdWorkerList(ctx context.Context, db Queryer) ([]entity.Worker, error)
+	GetRecdWorkerUserKey(ctx context.Context, db Queryer, worker entity.Worker) (string, error)
+	MergeRecdWorker(ctx context.Context, tx Execer, worker []entity.Worker) error
+	GetRecdDailyWorkerList(ctx context.Context, db Queryer) ([]entity.WorkerDaily, error)
+	GetRecdDailyWorkerChk(ctx context.Context, db Queryer, userKey string, date null.Time) (bool, error)
+	MergeRecdDailyWorker(ctx context.Context, tx Execer, worker []entity.WorkerDaily) error
 }
 
 type WorkHourStore interface {

--- a/csm-api/store/store_compare.go
+++ b/csm-api/store/store_compare.go
@@ -40,7 +40,7 @@ func (r *Repository) GetDailyWorkerList(ctx context.Context, db Queryer, compare
 		SELECT
 			T1.SNO,
 			T1.JNO,
-			T1.USER_ID,
+			T2.USER_ID,
 			T2.USER_NM,
 			T2.REG_NO,
 			CASE
@@ -54,7 +54,7 @@ func (r *Repository) GetDailyWorkerList(ctx context.Context, db Queryer, compare
 			T1.COMPARE_STATE,
 			T1.IS_DEADLINE
 		FROM IRIS_WORKER_DAILY_SET T1
-		LEFT JOIN IRIS_WORKER_SET T2 ON T1.SNO = T2.SNO AND T1.USER_ID = T2.USER_ID
+		LEFT JOIN IRIS_WORKER_SET T2 ON T1.SNO = T2.SNO AND T1.USER_KEY = T2.USER_KEY --T1.SNO = T2.SNO AND T1.USER_ID = T2.USER_ID
 		WHERE TRUNC(T1.RECORD_DATE) = TRUNC(:1)
 		AND T1.SNO = :2
 		AND (

--- a/jenkins/jenkins-pipeline-scipt-csm-api
+++ b/jenkins/jenkins-pipeline-scipt-csm-api
@@ -12,7 +12,7 @@ pipeline {
 
                         env.CSM_API_IMAGE_NAME = secrets['CSM-API-IMAGE-NAME']
                         env.CSM_API_TAR_FILE = secrets['CSM-API-TAR-FILE']
-                        env.CSM_API_DOCKER_NETWORK = secrets['CSM-API-DOCKER-NETWORK']
+                        env.CSM_DOCKER_NETWORK = secrets['CSM-DOCKER-NETWORK']
                         env.CSM_REMOTE_USER = secrets['CSM-REMOTE-USER']
                         env.CSM_REMOTE_SERVER = secrets['CSM-REMOTE-SERVER']
                         env.CSM_REMOTE_PATH = secrets['CSM-REMOTE-PATH']
@@ -28,7 +28,7 @@ pipeline {
                     set -e
                     echo "=== 도커 이미지 및 tar 생성 ==="
                     cd '${LOCAL_WORKSPACE_DIR}'
-                    docker build -t '${env.CSM_API_IMAGE_NAME}:latest' .
+                    docker build --build-arg CIMAGE_UID=1000 --build-arg CIMAGE_GID=1000 -t csm-api:latest .
                     docker save -o '${LOCAL_WORKSPACE_DIR}/${env.CSM_API_TAR_FILE}' '${env.CSM_API_IMAGE_NAME}:latest'
                     """
                 }
@@ -39,7 +39,7 @@ pipeline {
                 script {
                     def imageName = env.CSM_API_IMAGE_NAME
                     def tarFileName = env.CSM_API_TAR_FILE
-                    def dockerNetwork = env.CSM_API_DOCKER_NETWORK
+                    def dockerNetwork = env.CSM_DOCKER_NETWORK
                     def remoteUser = env.CSM_REMOTE_USER
                     def remoteServer = env.CSM_REMOTE_SERVER
                     def remotePath = env.CSM_REMOTE_PATH
@@ -87,13 +87,14 @@ pipeline {
 
                         echo "=== 새 컨테이너 실행 ==="
                         docker run -d --name "\${IMAGE_NAME}" \
-						  --network "\${DOCKER_NETWORK}" \
-						  --restart=unless-stopped \
-						  -p 8080:8080 \
-						  -v /etc/localtime:/etc/localtime:ro \
+                          --network "\${DOCKER_NETWORK}" \
+                          --restart=unless-stopped \
+                          -p 8080:8080 \
+                          -v /etc/localtime:/etc/localtime:ro \
                           -v /etc/timezone:/etc/timezone:ro \
-						  -v /tmp/data/csm:/tmp/data/csm \
-						  "\${IMAGE_NAME}:latest"
+                          -v /var/csm:/var/csm \
+                          -v /var/log/csm:/var/log/csm \
+                          "\${IMAGE_NAME}:latest"
                     '
                     """
                 }

--- a/jenkins/jenkins-pipeline-script-csm-front
+++ b/jenkins/jenkins-pipeline-script-csm-front
@@ -12,6 +12,7 @@ pipeline {
 
                         env.CSM_FRONT_IMAGE_NAME = secrets['CSM-FRONT-IMAGE-NAME']
                         env.CSM_FRONT_TAR_FILE = secrets['CSM-FRONT-TAR-FILE']
+                        env.CSM_DOCKER_NETWORK = secrets['CSM-DOCKER-NETWORK']
                         env.CSM_REMOTE_USER = secrets['CSM-REMOTE-USER']
                         env.CSM_REMOTE_SERVER = secrets['CSM-REMOTE-SERVER']
                         env.CSM_REMOTE_PATH = secrets['CSM-REMOTE-PATH']
@@ -40,6 +41,7 @@ pipeline {
                 script {
                     def imageName = env.CSM_FRONT_IMAGE_NAME
                     def tarFileName = env.CSM_FRONT_TAR_FILE
+                    def dockerNetwork = env.CSM_DOCKER_NETWORK
                     def remoteUser = env.CSM_REMOTE_USER
                     def remoteServer = env.CSM_REMOTE_SERVER
                     def remotePath = env.CSM_REMOTE_PATH
@@ -64,6 +66,7 @@ pipeline {
 
                         IMAGE_NAME="${imageName}"
                         TAR_FILE_NAME="${tarFileName}"
+                        DOCKER_NETWORK="${dockerNetwork}"
                         REMOTE_TAR_PATH="${remoteTarPath}"
 
                         echo "=== 기존 이미지 백업 ==="
@@ -85,7 +88,9 @@ pipeline {
                         fi
 
                         echo "=== 새 컨테이너 실행 ==="
-                        docker run -d --name "\${IMAGE_NAME}" --restart=unless-stopped -p 80:80 "\${IMAGE_NAME}:latest"
+                        docker run -d --name "\${IMAGE_NAME}" \
+                          --network "\${DOCKER_NETWORK}" \
+                          --restart=unless-stopped -p 80:80 "\${IMAGE_NAME}:latest"
                     '
                     """
                 }


### PR DESCRIPTION
1. 전체근로자 조회 조건 수정 : 가장 최근에 출퇴근한 기록이 조회
2. 홍채인식기 데이터 전체근로자, 현장근로자 테이블에 반영 : 스케줄러를 이용하여 5분 간격으로 반영이 되도록 함.
3. 로그 데이터 저장 : 운영 서버에 로그 데이터를 저장
- 한달동안만 유지되고 매일마다 새로운 파일로 저장
- `logrotate`를 이용하여 아카이브 방식 적용
4. 운영에서만 스케줄이 돌아가서 수정
5. 운영 파일 저장 경로 수정. config_prod.go : 기존 `/tmp` 경로는 임시 파일을 저장하는 장소이기 때문에 `/var` 경로로 변경
6. 젠킨스 파이프라인 수정
- 경로 접근 권한 문제로 cimage의 uid/gid를 동일하게 맞추기 위하여 도커빌드 명령어 수정
- 콘솔 로그파일 저장 경로 바인드 마운트 추가 및 기존 경로 수정
- 프론트에도 컨테이너 실행시 동일 네트워크 사용하도록 추가