### PR TITLE
panic-safe 도입 및 코드 구조 리팩토링

### DIFF
--- a/csm-api/handler/middleware.go
+++ b/csm-api/handler/middleware.go
@@ -2,7 +2,9 @@ package handler
 
 import (
 	"csm-api/auth"
+	"log"
 	"net/http"
+	"runtime/debug"
 )
 
 // api호출시 jwt를 확인하는 미들웨어
@@ -60,4 +62,16 @@ func AuthMiddleware(jwt *auth.JWTUtils) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, req)
 		})
 	}
+}
+
+func Recoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Printf("[panic] %v\n%s", err, debug.Stack())
+				http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
 }

--- a/csm-api/init.go
+++ b/csm-api/init.go
@@ -61,6 +61,7 @@ func (i *Init) RunInitializations(ctx context.Context) (err error) {
 
 	eg.Go(func() error {
 		// 현장 근로자 공수계산 (당일 이전 날짜 중에서 출퇴퇴근을 데이터가 모드 있는 근로자만 처리)
+		defer Recover("[init] ModifyWorkHour")
 		log.Println("[init] ModifyWorkHour start")
 		user := entity.Base{
 			ModUser: utils.ParseNullString("SYSTEM_INIT"),
@@ -72,25 +73,27 @@ func (i *Init) RunInitializations(ctx context.Context) (err error) {
 		return nil
 	})
 
-	eg.Go(func() error {
-		// 홍채인식기 전체근로자 반영
-		log.Println("[init] MergeRecdWorker start")
-		if initErr := i.WorkerService.MergeRecdWorker(ctx); initErr != nil {
-			return entity.WriteErrorLog(ctx, utils.CustomErrorf(initErr))
-		}
-		log.Println("[init] MergeRecdWorker completed")
-		return nil
-	})
-
-	eg.Go(func() error {
-		// 홍채인식기 현장근로자 반영
-		log.Println("[init] MergeRecdDailyWorker start")
-		if initErr := i.WorkerService.MergeRecdDailyWorker(ctx); initErr != nil {
-			return entity.WriteErrorLog(ctx, utils.CustomErrorf(initErr))
-		}
-		log.Println("[init] MergeRecdDailyWorker completed")
-		return nil
-	})
+	//eg.Go(func() error {
+	//	// 홍채인식기 전체근로자 반영
+	//	defer utils.Recover("[init] MergeRecdWorker")
+	//	log.Println("[init] MergeRecdWorker start")
+	//	if initErr := i.WorkerService.MergeRecdWorker(ctx); initErr != nil {
+	//		return entity.WriteErrorLog(ctx, utils.CustomErrorf(initErr))
+	//	}
+	//	log.Println("[init] MergeRecdWorker completed")
+	//	return nil
+	//})
+	//
+	//eg.Go(func() error {
+	//	// 홍채인식기 현장근로자 반영
+	//	defer utils.Recover("[init] MergeRecdDailyWorker")
+	//	log.Println("[init] MergeRecdDailyWorker start")
+	//	if initErr := i.WorkerService.MergeRecdDailyWorker(ctx); initErr != nil {
+	//		return entity.WriteErrorLog(ctx, utils.CustomErrorf(initErr))
+	//	}
+	//	log.Println("[init] MergeRecdDailyWorker completed")
+	//	return nil
+	//})
 
 	if err = eg.Wait(); err != nil {
 		return entity.WriteErrorLog(ctx, err)

--- a/csm-api/mux.go
+++ b/csm-api/mux.go
@@ -29,6 +29,7 @@ import (
 // chi패키지를 이용하여 http method에 따른 여러 요청을 라우팅 할 수 있음 함수 구현
 func newMux(ctx context.Context, safeDb *sqlx.DB, timesheetDb *sqlx.DB) (http.Handler, error) {
 	mux := chi.NewRouter()
+	mux.Use(handler.Recoverer)
 
 	// CORS 미들웨어 설정
 	c := cors.New(cors.Options{ // 허용할 도메인

--- a/csm-api/recover.go
+++ b/csm-api/recover.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"context"
+	"csm-api/entity"
+	"csm-api/utils"
+	"fmt"
+	"log"
+)
+
+func Recover(message string) {
+	if r := recover(); r != nil {
+		log.Printf("[panic][Scheduler-ModifyWorkerDeadlineSchedule]: %v", r)
+		_ = entity.WriteErrorLog(context.Background(), utils.CustomMessageErrorf(fmt.Sprintf("panic %s", message), fmt.Errorf("%v", r)))
+	}
+}

--- a/csm-api/scheduler.go
+++ b/csm-api/scheduler.go
@@ -94,8 +94,8 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// 근로자 마감 처리 (퇴근한 근로자만 처리)::0시 0분 0초
 	_, err := s.cron.AddFunc("0 0 0 * * *", func() {
+		defer Recover("[Scheduler] Running ModifyWorkerDeadlineSchedule")
 		log.Println("[Scheduler] Running ModifyWorkerDeadlineSchedule")
-
 		if err := s.WorkerService.ModifyWorkerDeadlineInit(ctx); err != nil {
 			log.Println("[Scheduler] ModifyWorkerDeadlineSchedule fail")
 			_ = entity.WriteErrorLog(ctx, utils.CustomMessageErrorf("[Scheduler] ModifyWorkerDeadlineSchedule", err))
@@ -122,6 +122,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// 프로젝트 정보 업데이트(초기 세팅)::5분
 	_, err = s.cron.AddFunc("0 0/5 * * * *", func() {
+		defer Recover("[Scheduler] Running CheckProjectSettings")
 		log.Println("[Scheduler] Running CheckProjectSettings")
 		var count int
 		if count, err = s.ProjectSettingService.CheckProjectSetting(ctx); err != nil {
@@ -137,6 +138,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// 근로자 공수 계산 (마감 처리가 안되고 출퇴근이 모두 있는 근로자)::0시 1분 0초
 	_, err = s.cron.AddFunc("0 1 0 * * *", func() {
+		defer Recover("[Scheduler] Running ModifyWorkHour")
 		log.Println("[Scheduler] Running ModifyWorkHour")
 		user := entity.Base{
 			ModUser: utils.ParseNullString("SYSTEM_BATCH"),
@@ -154,6 +156,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// 날씨 저장::8시, 10시, 13시, 15시, 17시
 	_, err = s.cron.AddFunc("0 0 8,10,13,15,17 * * *", func() {
+		defer Recover("[Scheduler] Running SaveWeather")
 		log.Println("[Scheduler] Running SaveWeather")
 
 		err = s.WeatherService.SaveWeather(ctx)
@@ -171,6 +174,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// 공정률 기록::00:00부터 05:00까지 1시간
 	_, err = s.cron.AddFunc("0 0 0,1,2,3,4,5 * * *", func() {
+		defer Recover("[Scheduler] Running SettingWorkRate")
 		log.Println("[Scheduler] Running SettingWorkRate")
 		var count int64
 		now := time.Now()
@@ -188,7 +192,8 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// 홍채인식기 전체근로자 반영::5분
 	_, err = s.cron.AddFunc("0 0/5 * * * *", func() {
-		log.Println("[Scheduler] Running ")
+		defer Recover("[Scheduler] Running MergeRecdWorker")
+		log.Println("[Scheduler] Running MergeRecdWorker")
 		if err = s.WorkerService.MergeRecdWorker(ctx); err != nil {
 			log.Println("[Scheduler] MergeRecdWorker fail")
 			_ = entity.WriteErrorLog(ctx, utils.CustomMessageErrorf("[Scheduler] MergeRecdWorker", err))
@@ -202,7 +207,8 @@ func (s *Scheduler) Run(ctx context.Context) error {
 
 	// 홍채인식기 현장근로자 반영::5분(정시 2분부터 시작)
 	_, err = s.cron.AddFunc("0 2-59/5 * * * *", func() {
-		log.Println("[Scheduler] Running ")
+		defer Recover("[Scheduler] Running MergeRecdDailyWorker")
+		log.Println("[Scheduler] Running MergeRecdDailyWorker")
 		if err = s.WorkerService.MergeRecdDailyWorker(ctx); err != nil {
 			log.Println("[Scheduler] MergeRecdDailyWorker fail")
 			_ = entity.WriteErrorLog(ctx, utils.CustomMessageErrorf("[Scheduler] MergeRecdDailyWorker", err))

--- a/csm-api/server.go
+++ b/csm-api/server.go
@@ -22,6 +22,7 @@ type Server struct {
 func (s *Server) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
+		defer Recover("HTTP Server Goroutine")
 		log.Println("HTTP server start")
 		if err := s.srv.Serve(s.l); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("failed to close: %+v", err)
@@ -46,6 +47,7 @@ func NewServer(l net.Listener, mux http.Handler) *Server {
 func (s *Server) Shutdown(ctx context.Context) error {
 	var shutdownErr error
 	s.shutdownOnce.Do(func() {
+		defer Recover("HTTP server shutdown")
 		log.Println("HTTP server shutdown initiated...")
 		if err := s.srv.Shutdown(ctx); err != nil {
 			log.Printf("HTTP server Shutdown error: %+v", err)


### PR DESCRIPTION
1. chi 라우터에 전역 Recoverer 미들웨어 적용으로 panic-safe 강화
2. goroutine/cron job에 recover 래퍼 추가하여 비HTTP panic-safe 보강