### PR TITLE
context canceled 문제 해결, 커넥션 점유/대기 이슈로 서비스 역할별 인스턴스 분리

### DIFF
--- a/csm-api/Dockerfile.schedule
+++ b/csm-api/Dockerfile.schedule
@@ -1,0 +1,33 @@
+# Go 빌드 환경 설정
+FROM golang:1.23.4 AS builder
+
+WORKDIR /app
+
+# Go 모듈 복사 및 종속성 설치
+COPY go.mod go.sum ./
+RUN go mod download
+
+# 소스 코드 복사 및 빌드
+COPY . .
+# 여기서 -tags schedule 지정!
+RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags schedule -o app-schedule
+
+# 실행 환경 설정
+FROM base-dependencies
+
+ARG CIMAGE_UID=101
+ARG CIMAGE_GID=101
+
+RUN addgroup --system --gid ${CIMAGE_GID} cimage \
+ && adduser --system --uid ${CIMAGE_UID} --gid ${CIMAGE_GID} --disabled-password --gecos "" cimage
+
+# Go 애플리케이션 복사 (이름 주의!)
+COPY --from=builder /app/app-schedule /app/
+
+WORKDIR /app
+
+RUN chown ${CIMAGE_UID}:${CIMAGE_GID} /app/app-schedule
+
+USER cimage
+
+CMD ["./app-schedule"]

--- a/csm-api/config/config.go
+++ b/csm-api/config/config.go
@@ -7,6 +7,7 @@ import (
 
 type Config struct {
 	Env            string `env:"ENV" envDefault:"local"`
+	Role           string `env:"ROLE" envDefault:"web"`
 	Port           int    `env:"PORT" envDefault:"8082"`
 	Domain         string `env:"DOMAIN" envDefault:"localhost"`
 	UploadPath     string `env:"UPLOAD_PATH" envDefault:"uploads"`

--- a/csm-api/config/config_dev.go
+++ b/csm-api/config/config_dev.go
@@ -16,6 +16,11 @@ func init() {
 		log.Fatalf("Failed to set ENV: %v", err)
 	}
 
+	err := os.Setenv("ROLE", "web")
+	if err != nil {
+		log.Fatalf("Failed to set ROLE: %v", err)
+	}
+
 	err = os.Setenv("DOMAIN", "127.0.0.1")
 	if err != nil {
 		log.Fatalf("Failed to set DOMAIN: %v", err)

--- a/csm-api/config/config_local.go
+++ b/csm-api/config/config_local.go
@@ -8,12 +8,17 @@ import (
 )
 
 func init() {
-	log.Println("start go:build dev")
+	log.Println("start go:build local")
 
 	// 개발 환경에 필요한 기본값 설정
 	err := os.Setenv("ENV", "development")
 	if err != nil {
 		log.Fatalf("Failed to set ENV: %v", err)
+	}
+
+	err = os.Setenv("ROLE", "web")
+	if err != nil {
+		log.Fatalf("Failed to set ROLE: %v", err)
 	}
 
 	err = os.Setenv("DOMAIN", "localhost")

--- a/csm-api/config/config_schedule.go
+++ b/csm-api/config/config_schedule.go
@@ -1,4 +1,4 @@
-//go:build prod
+//go:build schedule
 
 package config
 
@@ -8,15 +8,15 @@ import (
 )
 
 func init() {
-	log.Println("start go:build prod")
+	log.Println("start go:build schedule")
 
 	// 운영 환경에 필요한 기본값 설정
-	err := os.Setenv("ENV", "production")
+	err := os.Setenv("ENV", "schedule")
 	if err != nil {
 		log.Fatalf("Failed to set ENV: %v", err)
 	}
 
-	err = os.Setenv("ROLE", "web")
+	err = os.Setenv("ROLE", "schedule")
 	if err != nil {
 		log.Fatalf("Failed to set ROLE: %v", err)
 	}
@@ -52,7 +52,7 @@ func init() {
 		log.Fatalf("Failed to set EXCEL_PATH: %v", err)
 	}
 
-	err = os.Setenv("CONSOLE_LOG_PATH", "/var/log/csm")
+	err = os.Setenv("CONSOLE_LOG_PATH", "/var/log/csm/schedule")
 	if err != nil {
 		log.Fatalf("Failed to set EXCEL_PATH: %v", err)
 	}

--- a/csm-api/main.go
+++ b/csm-api/main.go
@@ -8,14 +8,11 @@ import (
 	"csm-api/store"
 	"csm-api/utils"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"io"
 	"log"
-	"net"
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 )
 
 func main() {
@@ -71,15 +68,6 @@ func run(ctx context.Context) error {
 		return utils.CustomMessageErrorf("config.NewConfig", err)
 	}
 
-	// domain, port 설정
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.Domain, cfg.Port))
-	if err != nil {
-		return utils.CustomMessageErrorf("net.Listen", err)
-	}
-
-	url := fmt.Sprintf("http://%s", l.Addr().String())
-	fmt.Printf("Listening at %s\n", url)
-
 	// DB config 설정
 	dbCfg, err := config.NewDBConfig()
 	if err != nil {
@@ -100,75 +88,37 @@ func run(ctx context.Context) error {
 	}
 	cleanup = append(cleanup, func() { timesheetCleanup() })
 
-	// api config 생성
-	apiCfg, err := config.GetApiConfig()
-	if err != nil {
-		return utils.CustomMessageErrorf("config.ApiConfig", err)
-	}
-
 	defer func() {
 		for _, clean := range cleanup {
 			clean()
 		}
 	}()
 
-	// 초기화 (Init 객체 생성)
-	init, err := NewInit(safeDb)
-	if err != nil {
-		return utils.CustomMessageErrorf("NewInit fail", err)
-	}
-	// 초기화 실행
-	err = init.RunInitializations(ctx)
-	if err != nil {
-		return utils.CustomMessageErrorf("RunInitializations", err)
-	}
-
-	// 라우팅 설정
-	mux, err := newMux(ctx, safeDb, timesheetDb)
-	if err != nil {
-		return utils.CustomMessageErrorf("newMux", err)
-	}
-
-	// HTTP server 생성
-	server := NewServer(l, mux)
-
-	// scheduler 생성
-	scheduler, err := NewScheduler(safeDb, apiCfg, timesheetDb)
-	if err != nil {
-		return utils.CustomMessageErrorf("NewScheduler", err)
-	}
-
-	// 서버와 스케줄러 동시에 실행
-	eg, ctx := errgroup.WithContext(ctx)
-
-	eg.Go(func() error {
-		return server.Run(ctx)
-	})
-
-	// 운영환경에서만 스케줄러 실행
 	env := os.Getenv("ENV")
-	if env == "production" {
-		eg.Go(func() error {
-			return scheduler.Run(ctx)
-		})
-	} else {
-		log.Printf("[INFO] Scheduler runs only when ENV=production. Current ENV: %s\n", env)
-	}
+	log.Printf("start go:build env:%s", env)
+	role := os.Getenv("ROLE")
+	log.Printf("start go:build role:%s", role)
 
-	// 종료 신호 대기
-	select {
-	case <-ctx.Done():
-		fmt.Println("\nShutdown signal received")
-
-		// 서버 shutdown (5초 안에 처리)
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		if err = server.Shutdown(shutdownCtx); err != nil {
-			return utils.CustomMessageErrorf("server graceful shutdown", err)
+	// 초기화 (Init 객체 생성)
+	if env == "development" || env == "local" {
+		init, err := NewInit(safeDb)
+		if err != nil {
+			return utils.CustomMessageErrorf("NewInit fail", err)
 		}
-		log.Println("Server exited normally.")
+		// 초기화 실행
+		err = init.RunInitializations(ctx)
+		if err != nil {
+			return utils.CustomMessageErrorf("RunInitializations", err)
+		}
 	}
 
-	return nil
+	switch role {
+	case "web":
+		return runWeb(ctx, cfg, safeDb, timesheetDb)
+	case "schedule":
+		return runSchedule(ctx, safeDb, timesheetDb)
+	default:
+		return runWeb(ctx, cfg, safeDb, timesheetDb)
+	}
+
 }

--- a/csm-api/run.go
+++ b/csm-api/run.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"csm-api/config"
+	"csm-api/utils"
+	"fmt"
+	"github.com/jmoiron/sqlx"
+	"golang.org/x/sync/errgroup"
+	"log"
+	"net"
+	"time"
+)
+
+func runWeb(ctx context.Context, cfg *config.Config, safeDb, timesheetDb *sqlx.DB) error {
+	// 포트/도메인 리스너
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", cfg.Domain, cfg.Port))
+	if err != nil {
+		return utils.CustomMessageErrorf("net.Listen", err)
+	}
+	url := fmt.Sprintf("http://%s", l.Addr().String())
+	log.Printf("Listening at %s\n", url)
+
+	// mux/route
+	mux, err := newMux(ctx, safeDb, timesheetDb)
+	if err != nil {
+		return utils.CustomMessageErrorf("newMux", err)
+	}
+
+	server := NewServer(l, mux)
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error { return server.Run(ctx) })
+
+	// 종료 신호 대기 및 graceful shutdown
+	select {
+	case <-ctx.Done():
+		fmt.Println("\nShutdown signal received")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return utils.CustomMessageErrorf("server graceful shutdown", err)
+		}
+		log.Println("Server exited normally.")
+	}
+
+	return eg.Wait()
+}
+
+func runSchedule(ctx context.Context, safeDb, timesheetDb *sqlx.DB) error {
+	apiCfg, err := config.GetApiConfig()
+	if err != nil {
+		return utils.CustomMessageErrorf("config.ApiConfig", err)
+	}
+	scheduler, err := NewScheduler(safeDb, apiCfg, timesheetDb)
+	if err != nil {
+		return utils.CustomMessageErrorf("NewScheduler", err)
+	}
+	// 스케줄러는 Run만 실행, 종료 신호는 내부에서 ctx.Done()으로 처리
+	return scheduler.Run(ctx)
+}

--- a/csm-api/scheduler.go
+++ b/csm-api/scheduler.go
@@ -223,7 +223,7 @@ func (s *Scheduler) Run(ctx context.Context) error {
 	// ... 추가 job 등록
 	s.cron.Start()
 
-	log.Println("[Scheduler] Cron started")
+	log.Println("Scheduler server start")
 
 	// ctx.Done() 기다리다가 종료
 	<-ctx.Done()

--- a/csm-api/service/service_weather.go
+++ b/csm-api/service/service_weather.go
@@ -109,7 +109,7 @@ func (s *ServiceWeather) GetWeatherWrnMsg() (entity.WeatherWrnMsgList, error) {
 		"JSON",                // 응답 자료 형식
 		startDate,             // 발표시각 from
 		endDate,               //endDate,                // 발표시각 to
-		"108")                 // stnId. 전국(108), 서울(109), 부산(159), 대구(143), 광주(156), 전주(146), 대전(133), 청주(131), 강릉(105), 제주(184)
+		"108") // stnId. 전국(108), 서울(109), 부산(159), 대구(143), 광주(156), 전주(146), 대전(133), 청주(131), 강릉(105), 제주(184)
 
 	// api call
 	body, err := api.CallGetAPI(url)
@@ -226,22 +226,15 @@ func (s *ServiceWeather) GetWeatherList(ctx context.Context, sno int64, targetDa
 // params:
 // -
 func (s *ServiceWeather) SaveWeather(ctx context.Context) (err error) {
-	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
-	if err != nil {
-		return utils.CustomErrorf(err)
-	}
-
-	defer txutil.DeferTx(tx, &err)
-
 	// IRIS_SITE_POS에 등록된 값들 불러오기
 	list, err := s.SitePosStore.GetSitePosList(ctx, s.SafeDB)
-
 	if err != nil {
 		err = utils.CustomErrorf(err)
 	}
 
+	// 날씨 조회
+	var weathers []entity.Weather
 	for _, site := range list {
-
 		// 장소를 바꿀 수 없는 경우
 		if site.Latitude.Valid == false || site.Longitude.Valid == false {
 			continue
@@ -273,8 +266,19 @@ func (s *ServiceWeather) SaveWeather(ctx context.Context) (err error) {
 		weather.Sno = site.Sno
 		weather.RecogTime = null.TimeFrom(now)
 
-		// weather 저장
-		if err = s.Store.SaveWeather(ctx, tx, *weather); err != nil {
+		weathers = append(weathers, *weather)
+	}
+
+	// weather 저장
+	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
+	if err != nil {
+		return utils.CustomErrorf(err)
+	}
+
+	defer txutil.DeferTx(tx, &err)
+
+	for i := range weathers {
+		if err = s.Store.SaveWeather(ctx, tx, weathers[i]); err != nil {
 			err = utils.CustomErrorf(err)
 		}
 	}

--- a/csm-api/store/repository.go
+++ b/csm-api/store/repository.go
@@ -30,7 +30,8 @@ func New(ctx context.Context, cfg *config.DBConfig) (*sqlx.DB, func(), error) {
 	P.PoolParams.MaxSessions = 10                  // 최대 세션 10개
 	P.PoolParams.SessionIncrement = 2              // 풀 확장할 때마다 +2
 	P.PoolParams.SessionTimeout = 60 * time.Second // 유휴 풀 세션 TTL
-	P.PoolParams.WaitTimeout = 10 * time.Second    // 풀 대기 최대 시간
+	//P.PoolParams.WaitTimeout = 10 * time.Second    // 풀 대기 최대 시간
+	P.PoolParams.WaitTimeout = 2 * time.Minute
 
 	// 디버깅 용도로 DSN 출력
 	fmt.Printf("DSN: %s\n", P.StringWithPassword())

--- a/jenkins/jenkins-pipeline-scipt-csm-schedule
+++ b/jenkins/jenkins-pipeline-scipt-csm-schedule
@@ -1,0 +1,110 @@
+pipeline {
+    agent any
+    environment {
+        LOCAL_WORKSPACE_DIR = '/tmp/csm-api'
+        //LOCAL_WORKSPACE_DIR = "${env.WORKSPACE}"
+    }
+    stages {
+        stage('Initialize Variables') {
+            steps {
+                withCredentials([string(credentialsId: 'htenc-csm-schedule', variable: 'SECRET_JSON')]) {
+                    script {
+                        def secrets = new groovy.json.JsonSlurper().parseText(SECRET_JSON)
+
+                        env.CSM_SCHEDULE_IMAGE_NAME = secrets['CSM-SCHEDULE-IMAGE-NAME']
+                        env.CSM_SCHEDULE_TAR_FILE = secrets['CSM-SCHEDULE-TAR-FILE']
+                        env.CSM_DOCKER_NETWORK = secrets['CSM-DOCKER-NETWORK']
+                        env.CSM_REMOTE_USER = secrets['CSM-REMOTE-USER']
+                        env.CSM_REMOTE_SERVER = secrets['CSM-REMOTE-SERVER']
+                        env.CSM_REMOTE_PATH = secrets['CSM-REMOTE-PATH']
+                        env.CSM_REMOTE_PASSWORD = secrets['CSM-REMOTE-PASSWORD']
+                    }
+                }
+            }
+        }
+        stage('Create Docker Image') {
+            steps {
+                script {
+                    sh """
+                    set -e
+                    echo "=== 도커 이미지 및 tar 생성 (스케줄러) ==="
+                    cd '${LOCAL_WORKSPACE_DIR}'
+                    docker build -f Dockerfile.schedule --build-arg CIMAGE_UID=1000 --build-arg CIMAGE_GID=1000 -t csm-schedule:latest .
+                    docker save -o '${LOCAL_WORKSPACE_DIR}/${env.CSM_SCHEDULE_TAR_FILE}' 'csm-schedule:latest'
+                    """
+                }
+            }
+        }
+        stage('Transfer and Deploy') {
+            steps {
+                script {
+                    def imageName = env.CSM_SCHEDULE_IMAGE_NAME
+                    def tarFileName = env.CSM_SCHEDULE_TAR_FILE
+                    def dockerNetwork = env.CSM_DOCKER_NETWORK
+                    def remoteUser = env.CSM_REMOTE_USER
+                    def remoteServer = env.CSM_REMOTE_SERVER
+                    def remotePath = env.CSM_REMOTE_PATH
+                    def remotePassword = env.CSM_REMOTE_PASSWORD
+                    def remoteTarPath = "${remotePath}/${tarFileName}"
+
+                    sh """
+                    set -e
+
+                    echo "=== 로컬 tar file 확인 ==="
+                    if [ ! -f '${LOCAL_WORKSPACE_DIR}/${tarFileName}' ]; then
+                        echo "Tar file not found: ${LOCAL_WORKSPACE_DIR}/${tarFileName}"
+                        exit 1
+                    fi
+
+                    echo "=== 서버에 tar file 전송 ==="
+                    sshpass -p '${remotePassword}' scp -o StrictHostKeyChecking=no '${LOCAL_WORKSPACE_DIR}/${tarFileName}' '${remoteUser}@${remoteServer}:${remotePath}'
+
+                    echo "=== 서버에 ssh 접속 및 컨테이너 재배포 ==="
+                    sshpass -p '${remotePassword}' ssh -o StrictHostKeyChecking=no '${remoteUser}@${remoteServer}' bash -c '
+                        set -e
+
+                        IMAGE_NAME="${imageName}"
+                        TAR_FILE_NAME="${tarFileName}"
+                        DOCKER_NETWORK="${dockerNetwork}"
+                        REMOTE_TAR_PATH="${remoteTarPath}"
+
+                        echo "=== 기존 이미지 백업 ==="
+                        if docker images | grep -w "\${IMAGE_NAME}"; then
+                            TIMESTAMP=\$(date +\"%Y%m%d%H%M\")
+                            BACKUP_IMAGE_NAME="\${IMAGE_NAME}_backup_\${TIMESTAMP}"
+                            docker tag "\${IMAGE_NAME}:latest" "\${BACKUP_IMAGE_NAME}:latest"
+                            docker rmi -f "\${IMAGE_NAME}:latest" || true
+                            echo "기존 이미지를 \${BACKUP_IMAGE_NAME}으로 백업했습니다."
+                        fi
+
+                        echo "=== 새로운 이미지 로드 ==="
+                        docker load -i "\${REMOTE_TAR_PATH}"
+
+                        echo "=== 기존 컨테이너 중지 및 삭제 ==="
+                        if docker ps -a | grep -w "\${IMAGE_NAME}"; then
+                            docker stop "\${IMAGE_NAME}" || true
+                            docker rm "\${IMAGE_NAME}" || true
+                        fi
+
+                        echo "=== 새 컨테이너 실행 ==="
+                        docker run -d --name "\${IMAGE_NAME}" \
+                          --network "\${DOCKER_NETWORK}" \
+                          --restart=unless-stopped \
+                          -p 8081:8081 \
+                          -v /etc/localtime:/etc/localtime:ro \
+                          -v /etc/timezone:/etc/timezone:ro \
+                          -v /var/csm:/var/csm \
+                          -v /var/log/csm/schedule:/var/log/csm/schedule \
+                          "\${IMAGE_NAME}:latest"
+                    '
+                    """
+                }
+            }
+        }
+    }
+    post {
+        always {
+            echo '스케줄러 배포 완료.'
+        }
+    }
+}


### PR DESCRIPTION
- Go의 database/sql에서 Oracle과 연동 시, 트랜잭션 세션 상태가 커넥션 풀에서 완전히 초기화되지 않아 여러 커넥션을 사용할 경우 `SET TRANSACTION must be first statement` 오류가 반복적으로 발생
- 이를 회피하기 위해 `MaxOpenConns=1`로 제한하여 단일 커넥션만 사용하니 한 작업이 커넥션을 점유하는 동안 다른 작업은 대기(`timeout`, `context canceled` 등) 현상이 발생
- 점유/대기 문제는 Go와 오라클 표준 드라이버 사이의 세션 관리 한계로 인해 쉽게 해결할 수 없는 구조적 문제이기 때문에, 하나의 서비스 인스턴스에서 여러 역할(Init, 스케줄러, API 서버 등)을 모두 처리하는 것은 병목현상이 일어날 수 밖에 없음. : init(초기화), 스케줄러, API 서버**를 빌드 태그로 구분하여 각각 별도의 프로세스(또는 컨테이너)로 실행하도록 구조 분리 : 각 역할별로 독립된 커넥션을 점유하도록 하여, 한쪽 작업 지연/실패가 다른 서비스에 영향 주지 않도록 개선

*** 추후 API 서버는 로드밸런싱 등을 적용하여, 트래픽 증가나 장애 상황에서도 서비스 안정성을 높일 계획