### PR TITLE
현장근로자 변경사유 로직 추가 및 공사관리프로젝트 조회 수정

### DIFF
--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -35,6 +35,7 @@ type WorkerDaily struct {
 	IrisNo          null.Int    `json:"iris_no" db:"IRIS_NO"`
 	Sno             null.Int    `json:"sno" db:"SNO"` //현장 고유번호
 	Jno             null.Int    `json:"jno" db:"JNO"` //프로젝트 고유번호
+	JobName         null.String `json:"job_name" db:"JOB_NAME"`
 	UserKey         null.String `json:"user_key" db:"USER_KEY"`
 	UserId          null.String `json:"user_id" db:"USER_ID"` //근로자 아이디
 	UserNm          null.String `json:"user_nm" db:"USER_NM"`
@@ -120,7 +121,9 @@ type WorkerTimeExcel struct {
 }
 
 type WorkerReason struct {
+	Cno        null.Int    `json:"cno" db:"CNO"`
 	Reason     null.String `json:"reason" db:"REASON"`
 	ReasonType null.String `json:"reason_type" db:"REASON_TYPE"`
 	HisStatus  null.String `json:"his_status" db:"HIS_STATUS"`
+	HisName    null.String `json:"his_name" db:"HIS_NAME"`
 }

--- a/csm-api/handler/handler_project.go
+++ b/csm-api/handler/handler_project.go
@@ -99,6 +99,7 @@ func (h *HandlerProject) RegList(w http.ResponseWriter, r *http.Request) {
 	jobSd := r.URL.Query().Get("job_sd")
 	jobEd := r.URL.Query().Get("job_ed")
 	cdNm := r.URL.Query().Get("cd_nm")
+	includeJno := r.URL.Query().Get("include_jno")
 	if pageNum == "" || rowSize == "" {
 		BadRequestResponse(ctx, w)
 		return
@@ -116,14 +117,14 @@ func (h *HandlerProject) RegList(w http.ResponseWriter, r *http.Request) {
 	search.CdNm = utils.ParseNullString(cdNm)
 
 	// 프로젝트 조회
-	list, err := h.Service.GetUsedProjectList(ctx, page, search, retry_search)
+	list, err := h.Service.GetUsedProjectList(ctx, page, search, retry_search, includeJno)
 	if err != nil {
 		FailResponse(ctx, w, err)
 		return
 	}
 
 	// 개수
-	count, err := h.Service.GetUsedProjectCount(ctx, search, retry_search)
+	count, err := h.Service.GetUsedProjectCount(ctx, search, retry_search, includeJno)
 	if err != nil {
 		FailResponse(ctx, w, err)
 		return

--- a/csm-api/handler/handler_worker.go
+++ b/csm-api/handler/handler_worker.go
@@ -420,3 +420,43 @@ func (h *HandlerWorker) ModifyWorkHours(w http.ResponseWriter, r *http.Request) 
 	entity.WriteLog(logEntry)
 	SuccessResponse(ctx, w)
 }
+
+// 변경이력 조회
+func (h *HandlerWorker) GetDailyWorkerHistory(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	startDate := r.URL.Query().Get("start_date")
+	endDate := r.URL.Query().Get("end_date")
+	snoString := r.URL.Query().Get("sno")
+	retrySearch := r.URL.Query().Get("retry_search")
+	if startDate == "" || endDate == "" || snoString == "" {
+		BadRequestResponse(ctx, w)
+		return
+	}
+
+	sno, _ := strconv.ParseInt(snoString, 10, 64)
+
+	list, err := h.Service.GetHistoryDailyWorkers(ctx, startDate, endDate, sno, retrySearch)
+	if err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+	SuccessValuesResponse(ctx, w, list)
+}
+
+// 변경 이력 사유 조회
+func (h *HandlerWorker) GetDailyWorkerHistoryReason(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	cnoString := r.URL.Query().Get("cno")
+	if cnoString == "" {
+		BadRequestResponse(ctx, w)
+		return
+	}
+	cno, _ := strconv.ParseInt(cnoString, 10, 64)
+	list, err := h.Service.GetHistoryDailyWorkerReason(ctx, cno)
+	if err != nil {
+		FailResponse(ctx, w, err)
+		return
+	}
+	SuccessValuesResponse(ctx, w, list)
+}

--- a/csm-api/route/route_worker.go
+++ b/csm-api/route/route_worker.go
@@ -33,6 +33,8 @@ func WorkerRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 	router.Post("/site-base/deadline-cancel", workerHandler.SiteBaseDeadlineCancel) // 마감 취소
 	router.Get("/site-base/record", workerHandler.DailyWorkersByJnoAndDate)         // 프로젝트, 기간내 모든 현장근로자 근태정보 조회
 	router.Post("/site-base/work-hours", workerHandler.ModifyWorkHours)             // 현장근로자 일괄 공수 변경
+	router.Get("/site-base/history", workerHandler.GetDailyWorkerHistory)           // 변경 이력 조회
+	router.Get("/site-base/reason", workerHandler.GetDailyWorkerHistoryReason)      // 변경 이력 사유 조회
 
 	return router
 }

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -44,8 +44,8 @@ type ProjectService interface {
 	GetProjectList(ctx context.Context, sno int64, targetDate time.Time) (*entity.ProjectInfos, error)
 	GetProjectWorkerCountList(ctx context.Context, targetDate time.Time) (*entity.ProjectInfos, error)
 	GetProjectNmList(ctx context.Context) (*entity.ProjectInfos, error)
-	GetUsedProjectList(ctx context.Context, page entity.Page, search entity.JobInfo, retry string) (*entity.JobInfos, error)
-	GetUsedProjectCount(ctx context.Context, search entity.JobInfo, retry string) (int, error)
+	GetUsedProjectList(ctx context.Context, page entity.Page, search entity.JobInfo, retry string, includeJno string) (*entity.JobInfos, error)
+	GetUsedProjectCount(ctx context.Context, search entity.JobInfo, retry string, includeJno string) (int, error)
 	GetAllProjectList(ctx context.Context, page entity.Page, search entity.JobInfo, isAll int, retry string) (*entity.JobInfos, error)
 	GetAllProjectCount(ctx context.Context, search entity.JobInfo, isAll int, retry string) (int, error)
 	GetStaffProjectList(ctx context.Context, page entity.Page, search entity.JobInfo, uno int64) (*entity.JobInfos, error)
@@ -138,6 +138,8 @@ type WorkerService interface {
 	ModifyWorkHours(ctx context.Context, workers entity.WorkerDailys) error
 	MergeRecdWorker(ctx context.Context) error
 	MergeRecdDailyWorker(ctx context.Context) error
+	GetHistoryDailyWorkers(ctx context.Context, startDate string, endDate string, sno int64, retry string) (entity.WorkerDailys, error)
+	GetHistoryDailyWorkerReason(ctx context.Context, cno int64) (string, error)
 }
 
 type WorkHourService interface {

--- a/csm-api/service/service_project.go
+++ b/csm-api/service/service_project.go
@@ -119,14 +119,14 @@ func (p *ServiceProject) GetProjectNmList(ctx context.Context) (*entity.ProjectI
 // func: 공사관리시스템 등록 프로젝트 전체 조회
 // @param
 // -
-func (p *ServiceProject) GetUsedProjectList(ctx context.Context, page entity.Page, search entity.JobInfo, retry string) (*entity.JobInfos, error) {
+func (p *ServiceProject) GetUsedProjectList(ctx context.Context, page entity.Page, search entity.JobInfo, retry string, includeJno string) (*entity.JobInfos, error) {
 	pageSql := entity.PageSql{}
 	pageSql, err := pageSql.OfPageSql(page)
 	if err != nil {
 		return &entity.JobInfos{}, utils.CustomErrorf(err)
 	}
 
-	jobInfos, err := p.Store.GetUsedProjectList(ctx, p.SafeDB, pageSql, search, retry)
+	jobInfos, err := p.Store.GetUsedProjectList(ctx, p.SafeDB, pageSql, search, retry, includeJno)
 	if err != nil {
 		return &entity.JobInfos{}, utils.CustomErrorf(err)
 	}
@@ -137,8 +137,8 @@ func (p *ServiceProject) GetUsedProjectList(ctx context.Context, page entity.Pag
 // func: 프로젝트 전체 조회 개수
 // @param
 // -
-func (p *ServiceProject) GetUsedProjectCount(ctx context.Context, search entity.JobInfo, retry string) (int, error) {
-	count, err := p.Store.GetUsedProjectCount(ctx, p.SafeDB, search, retry)
+func (p *ServiceProject) GetUsedProjectCount(ctx context.Context, search entity.JobInfo, retry string, includeJno string) (int, error) {
+	count, err := p.Store.GetUsedProjectCount(ctx, p.SafeDB, search, retry, includeJno)
 	if err != nil {
 		return 0, utils.CustomErrorf(err)
 	}

--- a/csm-api/service/service_weather.go
+++ b/csm-api/service/service_weather.go
@@ -109,7 +109,7 @@ func (s *ServiceWeather) GetWeatherWrnMsg() (entity.WeatherWrnMsgList, error) {
 		"JSON",                // 응답 자료 형식
 		startDate,             // 발표시각 from
 		endDate,               //endDate,                // 발표시각 to
-		"108") // stnId. 전국(108), 서울(109), 부산(159), 대구(143), 광주(156), 전주(146), 대전(133), 청주(131), 강릉(105), 제주(184)
+		"108")                 // stnId. 전국(108), 서울(109), 부산(159), 대구(143), 광주(156), 전주(146), 대전(133), 청주(131), 강릉(105), 제주(184)
 
 	// api call
 	body, err := api.CallGetAPI(url)

--- a/csm-api/service/service_worker.go
+++ b/csm-api/service/service_worker.go
@@ -186,6 +186,7 @@ func (s *ServiceWorker) GetWorkerSiteBaseCount(ctx context.Context, search entit
 // @param
 // -
 func (s *ServiceWorker) MergeSiteBaseWorker(ctx context.Context, workers entity.WorkerDailys) (err error) {
+	// 변경전 데이터 조회
 	beforeList, err := s.Store.GetDailyWorkerBeforeList(ctx, s.SafeDB, workers)
 	if err != nil {
 		return utils.CustomErrorf(err)
@@ -234,6 +235,12 @@ func (s *ServiceWorker) MergeSiteBaseWorker(ctx context.Context, workers entity.
 // @param
 // -
 func (s *ServiceWorker) ModifyWorkerDeadline(ctx context.Context, workers entity.WorkerDailys) (err error) {
+	// 변경전 데이터 조회
+	beforeList, err := s.Store.GetDailyWorkerBeforeList(ctx, s.SafeDB, workers)
+	if err != nil {
+		return utils.CustomErrorf(err)
+	}
+
 	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
@@ -250,6 +257,26 @@ func (s *ServiceWorker) ModifyWorkerDeadline(ctx context.Context, workers entity
 	if err = s.Store.MergeSiteBaseWorkerLog(ctx, tx, workers); err != nil {
 		return utils.CustomErrorf(err)
 	}
+
+	// 변경이력 저장
+	regDate := null.NewTime(time.Now(), true)
+	// 변경전
+	for i := range beforeList {
+		beforeList[i].HisStatus = utils.ParseNullString("BEFORE")
+		beforeList[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, beforeList); err != nil {
+		return utils.CustomErrorf(err)
+	}
+	// 변경후
+	for i := range workers {
+		workers[i].HisStatus = utils.ParseNullString("AFTER")
+		workers[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, workers); err != nil {
+		return utils.CustomErrorf(err)
+	}
+
 	return
 }
 
@@ -257,6 +284,12 @@ func (s *ServiceWorker) ModifyWorkerDeadline(ctx context.Context, workers entity
 // @param
 // -
 func (s *ServiceWorker) ModifyWorkerProject(ctx context.Context, workers entity.WorkerDailys) (err error) {
+	// 변경전 데이터 조회
+	beforeList, err := s.Store.GetDailyWorkerBeforeList(ctx, s.SafeDB, workers)
+	if err != nil {
+		return utils.CustomErrorf(err)
+	}
+
 	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
@@ -276,6 +309,26 @@ func (s *ServiceWorker) ModifyWorkerProject(ctx context.Context, workers entity.
 
 	// 프로젝트 변경 로그 저장
 	if err = s.Store.MergeSiteBaseWorkerLog(ctx, tx, workers); err != nil {
+		return utils.CustomErrorf(err)
+	}
+
+	// 변경이력 저장
+	regDate := null.NewTime(time.Now(), true)
+	// 변경전
+	for i := range beforeList {
+		beforeList[i].HisStatus = utils.ParseNullString("BEFORE")
+		beforeList[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, beforeList); err != nil {
+		return utils.CustomErrorf(err)
+	}
+	// 변경후
+	for i := range workers {
+		workers[i].HisStatus = utils.ParseNullString("AFTER")
+		workers[i].RegDate = regDate
+		workers[i].Jno = workers[i].AfterJno
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, workers); err != nil {
 		return utils.CustomErrorf(err)
 	}
 
@@ -352,11 +405,44 @@ func (s *ServiceWorker) RemoveSiteBaseWorkers(ctx context.Context, workers entit
 		return utils.CustomErrorf(err)
 	}
 
+	// 변경이력 저장
+	regDate := null.NewTime(time.Now(), true)
+	// 변경전
+	for i := range workers {
+		workers[i].HisStatus = utils.ParseNullString("BEFORE")
+		workers[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, workers); err != nil {
+		return utils.CustomErrorf(err)
+	}
+	// 변경후
+	for i := range workers {
+		workers[i].HisStatus = utils.ParseNullString("AFTER")
+		workers[i].Sno = null.NewInt(0, false)
+		workers[i].Jno = null.NewInt(0, false)
+		workers[i].RecordDate = null.NewTime(time.Time{}, false)
+		workers[i].InRecogTime = null.NewTime(time.Time{}, false)
+		workers[i].OutRecogTime = null.NewTime(time.Time{}, false)
+		workers[i].IsDeadline = null.NewString("", false)
+		workers[i].WorkState = null.NewString("", false)
+		workers[i].IsOvertime = null.NewString("", false)
+		workers[i].WorkHour = null.NewFloat(0, false)
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, workers); err != nil {
+		return utils.CustomErrorf(err)
+	}
+
 	return
 }
 
 // 마감 취소
 func (s *ServiceWorker) ModifyDeadlineCancel(ctx context.Context, workers entity.WorkerDailys) (err error) {
+	// 변경전 데이터 조회
+	beforeList, err := s.Store.GetDailyWorkerBeforeList(ctx, s.SafeDB, workers)
+	if err != nil {
+		return utils.CustomErrorf(err)
+	}
+
 	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
@@ -374,6 +460,25 @@ func (s *ServiceWorker) ModifyDeadlineCancel(ctx context.Context, workers entity
 		return utils.CustomErrorf(err)
 	}
 
+	// 변경이력 저장
+	regDate := null.NewTime(time.Now(), true)
+	// 변경전
+	for i := range beforeList {
+		beforeList[i].HisStatus = utils.ParseNullString("BEFORE")
+		beforeList[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, beforeList); err != nil {
+		return utils.CustomErrorf(err)
+	}
+	// 변경후
+	for i := range workers {
+		workers[i].HisStatus = utils.ParseNullString("AFTER")
+		workers[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, workers); err != nil {
+		return utils.CustomErrorf(err)
+	}
+
 	return
 }
 
@@ -388,6 +493,12 @@ func (s *ServiceWorker) GetDailyWorkersByJnoAndDate(ctx context.Context, param e
 
 // 현장근로자 일괄 공수 변경
 func (s *ServiceWorker) ModifyWorkHours(ctx context.Context, workers entity.WorkerDailys) (err error) {
+	// 변경전 데이터 조회
+	beforeList, err := s.Store.GetDailyWorkerBeforeList(ctx, s.SafeDB, workers)
+	if err != nil {
+		return utils.CustomErrorf(err)
+	}
+
 	tx, err := txutil.BeginTxWithMode(ctx, s.SafeTDB, false)
 	if err != nil {
 		return utils.CustomErrorf(err)
@@ -402,6 +513,25 @@ func (s *ServiceWorker) ModifyWorkHours(ctx context.Context, workers entity.Work
 
 	// 공수 변경 로그 저장
 	if err = s.Store.MergeSiteBaseWorkerLog(ctx, tx, workers); err != nil {
+		return utils.CustomErrorf(err)
+	}
+
+	// 변경이력 저장
+	regDate := null.NewTime(time.Now(), true)
+	// 변경전
+	for i := range beforeList {
+		beforeList[i].HisStatus = utils.ParseNullString("BEFORE")
+		beforeList[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, beforeList); err != nil {
+		return utils.CustomErrorf(err)
+	}
+	// 변경후
+	for i := range workers {
+		workers[i].HisStatus = utils.ParseNullString("AFTER")
+		workers[i].RegDate = regDate
+	}
+	if err = s.Store.AddHistoryDailyWorkers(ctx, tx, workers); err != nil {
 		return utils.CustomErrorf(err)
 	}
 
@@ -509,4 +639,22 @@ func (s *ServiceWorker) MergeRecdDailyWorker(ctx context.Context) (err error) {
 		return utils.CustomErrorf(err)
 	}
 	return
+}
+
+// 변경 이력 조회
+func (s *ServiceWorker) GetHistoryDailyWorkers(ctx context.Context, startDate string, endDate string, sno int64, retry string) (entity.WorkerDailys, error) {
+	list, err := s.Store.GetHistoryDailyWorkers(ctx, s.SafeDB, startDate, endDate, sno, retry)
+	if err != nil {
+		return entity.WorkerDailys{}, utils.CustomErrorf(err)
+	}
+	return list, nil
+}
+
+// 변경 이력 사유 조회
+func (s *ServiceWorker) GetHistoryDailyWorkerReason(ctx context.Context, cno int64) (string, error) {
+	reason, err := s.Store.GetHistoryDailyWorkerReason(ctx, s.SafeDB, cno)
+	if err != nil {
+		return "", utils.CustomErrorf(err)
+	}
+	return reason, nil
 }

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -52,8 +52,8 @@ type ProjectStore interface {
 	GetProjectWorkerCountList(ctx context.Context, db Queryer, targetDate time.Time) (*entity.ProjectInfos, error)
 	GetProjectSafeWorkerCountList(ctx context.Context, db Queryer, targetDate time.Time) (*entity.ProjectSafeCounts, error)
 	GetProjectNmList(ctx context.Context, db Queryer) (*entity.ProjectInfos, error)
-	GetUsedProjectList(ctx context.Context, db Queryer, pageSql entity.PageSql, search entity.JobInfo, retry string) (*entity.JobInfos, error)
-	GetUsedProjectCount(ctx context.Context, db Queryer, search entity.JobInfo, retry string) (int, error)
+	GetUsedProjectList(ctx context.Context, db Queryer, pageSql entity.PageSql, search entity.JobInfo, retry string, includeJno string) (*entity.JobInfos, error)
+	GetUsedProjectCount(ctx context.Context, db Queryer, search entity.JobInfo, retry string, includeJno string) (int, error)
 	GetAllProjectList(ctx context.Context, db Queryer, pageSql entity.PageSql, search entity.JobInfo, isAll int, retry string) (*entity.JobInfos, error)
 	GetAllProjectCount(ctx context.Context, db Queryer, search entity.JobInfo, retry string) (int, error)
 	GetStaffProjectList(ctx context.Context, db Queryer, pageSql entity.PageSql, searchSql entity.JobInfo, uno sql.NullInt64) (*entity.JobInfos, error)
@@ -165,6 +165,8 @@ type WorkerStore interface {
 	MergeRecdDailyWorker(ctx context.Context, tx Execer, worker []entity.WorkerDaily) error
 	GetDailyWorkerBeforeList(ctx context.Context, db Queryer, workers entity.WorkerDailys) (entity.WorkerDailys, error)
 	AddHistoryDailyWorkers(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
+	GetHistoryDailyWorkers(ctx context.Context, db Queryer, startDate string, endDate string, sno int64, retry string) (entity.WorkerDailys, error)
+	GetHistoryDailyWorkerReason(ctx context.Context, db Queryer, cno int64) (string, error)
 }
 
 type WorkHourStore interface {

--- a/csm-api/store/store_project.go
+++ b/csm-api/store/store_project.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -364,7 +365,7 @@ func (r *Repository) GetProjectNmList(ctx context.Context, db Queryer) (*entity.
 // func: 공사관리시스템 등록 프로젝트 전체 조회
 // @param
 // -
-func (r *Repository) GetUsedProjectList(ctx context.Context, db Queryer, pageSql entity.PageSql, search entity.JobInfo, retry string) (*entity.JobInfos, error) {
+func (r *Repository) GetUsedProjectList(ctx context.Context, db Queryer, pageSql entity.PageSql, search entity.JobInfo, retry string, includeJno string) (*entity.JobInfos, error) {
 	list := entity.JobInfos{}
 
 	condition := ""
@@ -388,6 +389,17 @@ func (r *Repository) GetUsedProjectList(ctx context.Context, db Queryer, pageSql
 		order = pageSql.Order.String
 	} else {
 		order = "JNO DESC, JOB_NO ASC"
+	}
+
+	var jnoCondition string
+	if includeJno != "undefined" && includeJno != "" {
+		parseInt, _ := strconv.ParseInt(includeJno, 10, 64)
+		jnoCondition = fmt.Sprintf(`
+			AND t1.SNO = (
+				SELECT SNO
+				FROM IRIS_SITE_JOB
+				WHERE JNO = %d
+			)`, parseInt)
 	}
 
 	query := fmt.Sprintf(`
@@ -414,12 +426,12 @@ func (r *Repository) GetUsedProjectList(ctx context.Context, db Queryer, pageSql
 							INNER JOIN TIMESHEET.SYS_CODE_SET t5 ON t5.MINOR_CD = t2.job_state AND t5.major_cd = 'JOB_STATE'
 						WHERE t1.SNO > 100
 						AND t1.IS_USE = 'Y'
-						%s %s
+						%s %s %s
 						ORDER BY %s
 					) sorted_data
 					WHERE ROWNUM <= :1
 				)
-				WHERE RNUM > :2`, condition, retryCondition, order)
+				WHERE RNUM > :2`, jnoCondition, condition, retryCondition, order)
 
 	if err := db.SelectContext(ctx, &list, query, pageSql.EndNum, pageSql.StartNum); err != nil {
 		return nil, utils.CustomErrorf(err)
@@ -431,7 +443,7 @@ func (r *Repository) GetUsedProjectList(ctx context.Context, db Queryer, pageSql
 // func: 공사관리시스템 등록 프로젝트 전체 조회 개수
 // @param
 // -
-func (r *Repository) GetUsedProjectCount(ctx context.Context, db Queryer, search entity.JobInfo, retry string) (int, error) {
+func (r *Repository) GetUsedProjectCount(ctx context.Context, db Queryer, search entity.JobInfo, retry string, includeJno string) (int, error) {
 	var count int
 
 	condition := ""
@@ -450,6 +462,17 @@ func (r *Repository) GetUsedProjectCount(ctx context.Context, db Queryer, search
 	columns = append(columns, "t2.JOB_PM_NAME")
 	retryCondition := utils.RetrySearchTextConvert(retry, columns)
 
+	var jnoCondition string
+	if includeJno != "undefined" && includeJno != "" {
+		parseInt, _ := strconv.ParseInt(includeJno, 10, 64)
+		jnoCondition = fmt.Sprintf(`
+			AND t1.SNO = (
+				SELECT SNO
+				FROM IRIS_SITE_JOB
+				WHERE JNO = %d
+			)`, parseInt)
+	}
+
 	query := fmt.Sprintf(`
 				SELECT 
 					COUNT(*)
@@ -461,7 +484,7 @@ func (r *Repository) GetUsedProjectCount(ctx context.Context, db Queryer, search
 					INNER JOIN TIMESHEET.SYS_CODE_SET t5 ON t5.MINOR_CD = t2.job_state AND t5.major_cd = 'JOB_STATE'
 				WHERE t1.SNO > 100
 				AND t1.IS_USE = 'Y'
-				%s %s`, condition, retryCondition)
+				%s %s %s`, jnoCondition, condition, retryCondition)
 
 	if err := db.GetContext(ctx, &count, query); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
1. 공사관리프로젝트 조회시 프로젝트번호를 주는 경우 같은 현장의 프로젝트만 조회할 수 있도록 변경
2. 현장근로자 데이터 변경시 `변경이력, 사유`를 같이 저장하도록 추가
3. 현장근로자 `변경이력, 사유` 조회 추가
4. 통합검색(결과내재검색)을 위한 where절 생성 헬퍼함수(`RetrySearchTextConvert`) 기능 추가
- 검색값을 `;` 로 연결시 `AND`가 아닌 `OR`로 연결
- 검색값 뒤에 '?'로 컬럼명이 있을 시 해당 컬럼명만 검색