### PR TITLE
엑셀 업로드 로직 수정

### DIFF
--- a/csm-api/entity/compare.go
+++ b/csm-api/entity/compare.go
@@ -10,6 +10,7 @@ type Compare struct {
 	UserNm           null.String `json:"user_nm" db:"USER_NM"`
 	Department       null.String `json:"department" db:"DEPARTMENT"`
 	DiscName         null.String `json:"disc_name" db:"DISC_NAME"`
+	Phone            null.String `json:"phone" db:"PHONE"`
 	Gender           null.String `json:"gender" db:"GENDER"`
 	IsTbm            null.String `json:"is_tbm" db:"IS_TBM"`
 	DeviceNm         null.String `json:"device_nm" db:"DEVICE_NM"`

--- a/csm-api/entity/worker.go
+++ b/csm-api/entity/worker.go
@@ -33,6 +33,7 @@ type Workers []*Worker
 type WorkerDaily struct {
 	RowNum          null.Int    `json:"rnum" db:"RNUM"`
 	IrisNo          null.Int    `json:"iris_no" db:"IRIS_NO"`
+	Dno             null.String `json:"dno" db:"DNO"`
 	Sno             null.Int    `json:"sno" db:"SNO"` //현장 고유번호
 	Jno             null.Int    `json:"jno" db:"JNO"` //프로젝트 고유번호
 	JobName         null.String `json:"job_name" db:"JOB_NAME"`
@@ -41,6 +42,7 @@ type WorkerDaily struct {
 	UserNm          null.String `json:"user_nm" db:"USER_NM"`
 	Department      null.String `json:"department" db:"DEPARTMENT"`
 	DiscName        null.String `json:"disc_name" db:"DISC_NAME"` // 공종명
+	Phone           null.String `json:"phone" db:"PHONE"`
 	RegNo           null.String `json:"reg_no" db:"REG_NO"`
 	RecordDate      null.Time   `json:"record_date" db:"RECORD_DATE"`
 	InRecogTime     null.Time   `json:"in_recog_time" db:"IN_RECOG_TIME"`   //출근시간
@@ -70,6 +72,7 @@ type WorkerOverTime struct {
 type WorkerOverTimes []*WorkerOverTime
 
 type WorkerDailyExcel struct {
+	RegNo      string
 	Department string
 	UserNm     string
 	Phone      string

--- a/csm-api/route/route_excel.go
+++ b/csm-api/route/route_excel.go
@@ -17,6 +17,7 @@ func ExcelRoute(safeDB *sqlx.DB, r *store.Repository) chi.Router {
 			SafeTDB:     safeDB,
 			Store:       r,
 			WorkerStore: r,
+			FileStore:   r,
 		},
 		FileService: &service.ServiceUploadFile{
 			DB:    safeDB,

--- a/csm-api/service/service.go
+++ b/csm-api/service/service.go
@@ -186,9 +186,9 @@ type ScheduleService interface {
 }
 
 type ExcelService interface {
-	ImportTbm(ctx context.Context, path string, tbm entity.Tbm) error
-	ImportDeduction(ctx context.Context, path string, deduction entity.Deduction) error
-	ImportAddDailyWorker(ctx context.Context, path string, worker entity.WorkerDaily) error
+	ImportTbm(ctx context.Context, path string, tbm entity.Tbm, file entity.UploadFile) error
+	ImportDeduction(ctx context.Context, path string, deduction entity.Deduction, file entity.UploadFile) error
+	ImportAddDailyWorker(ctx context.Context, path string, worker entity.WorkerDaily) (entity.WorkerDailys, error)
 }
 
 type UploadFileService interface {

--- a/csm-api/service/service_compare.go
+++ b/csm-api/service/service_compare.go
@@ -98,7 +98,13 @@ func (s *ServiceCompare) GetCompareList(ctx context.Context, compare entity.Comp
 	// TBM map: 동명이인 고려한 slice map
 	tbmMap := make(map[entity.TbmKey][]entity.Tbm)
 	for _, tbm := range tbmList {
-		key := entity.TbmKey{tbm.Sno.Int64, tbm.Jno.Int64, tbm.UserNm.String, tbm.Department.String, tbm.TbmDate.Time}
+		key := entity.TbmKey{
+			tbm.Sno.Int64,
+			0,
+			//tbm.Jno.Int64,
+			tbm.UserNm.String,
+			tbm.Department.String,
+			tbm.TbmDate.Time}
 		tbmMap[key] = append(tbmMap[key], tbm)
 	}
 
@@ -108,7 +114,8 @@ func (s *ServiceCompare) GetCompareList(ctx context.Context, compare entity.Comp
 	for _, d := range deductionList {
 		regKey := entity.DeductionRegKey{
 			d.Sno.Int64,
-			d.Jno.Int64,
+			0,
+			//d.Jno.Int64,
 			replacer.Replace(d.Phone.String),
 			cleanBirthRegNo(d.RegNo.String, d.Gender.String),
 			d.RecordDate.Time,
@@ -116,7 +123,8 @@ func (s *ServiceCompare) GetCompareList(ctx context.Context, compare entity.Comp
 		deductionRegMap[regKey] = d
 		key := entity.DeductionKey{
 			d.Sno.Int64,
-			d.Jno.Int64,
+			0,
+			//d.Jno.Int64,
 			d.UserNm.String,
 			d.Department.String,
 			d.RecordDate.Time,
@@ -134,6 +142,7 @@ func (s *ServiceCompare) GetCompareList(ctx context.Context, compare entity.Comp
 			UserNm:        worker.UserNm,
 			Department:    worker.Department,
 			DiscName:      worker.DiscName,
+			Phone:         worker.Phone,
 			Gender:        utils.ParseNullString(getBirthToRegNo(worker.RegNo.String)),
 			IsTbm:         utils.ParseNullString("N"),
 			DeviceNm:      worker.DeviceNm,
@@ -152,9 +161,9 @@ func (s *ServiceCompare) GetCompareList(ctx context.Context, compare entity.Comp
 			worker.Department.String,
 			worker.RecordDate.Time,
 		}
-		if worker.CompareState.String == "S" || worker.CompareState.String == "X" {
-			tbmKey.Jno = worker.Jno.Int64
-		}
+		//if worker.CompareState.String == "S" || worker.CompareState.String == "X" {
+		//	tbmKey.Jno = worker.Jno.Int64
+		//}
 		if tbms, ok := tbmMap[tbmKey]; ok && len(tbms) > 0 {
 			compareTemp.IsTbm = utils.ParseNullString("Y")
 			compareTemp.DiscName = tbms[0].DiscName
@@ -168,13 +177,13 @@ func (s *ServiceCompare) GetCompareList(ctx context.Context, compare entity.Comp
 		deductKey := entity.DeductionRegKey{
 			worker.Sno.Int64,
 			0,
-			replacer.Replace(worker.UserId.String),
+			replacer.Replace(worker.Phone.String),
 			cleanRegNo(worker.RegNo.String),
 			worker.RecordDate.Time,
 		}
-		if worker.CompareState.String == "S" || worker.CompareState.String == "X" {
-			deductKey.Jno = worker.Jno.Int64
-		}
+		//if worker.CompareState.String == "S" || worker.CompareState.String == "X" {
+		//	deductKey.Jno = worker.Jno.Int64
+		//}
 
 		if deduction, ok := deductionRegMap[deductKey]; ok {
 			compareTemp.DeductionInTime = deduction.InRecogTime

--- a/csm-api/store/store.go
+++ b/csm-api/store/store.go
@@ -156,7 +156,8 @@ type WorkerStore interface {
 	DeleteWorkerOverTime(ctx context.Context, tx Execer, cno null.Int) error
 	RemoveSiteBaseWorkers(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	ModifyDeadlineCancel(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
-	AddDailyWorkers(ctx context.Context, db Queryer, tx Execer, workers []entity.WorkerDaily) (entity.WorkerDailys, error)
+	GetDailyWorkerUserKey(ctx context.Context, db Queryer, worker entity.WorkerDaily) (string, error)
+	AddDailyWorkers(ctx context.Context, db Queryer, tx Execer, workers entity.WorkerDailys) (entity.WorkerDailys, error)
 	GetDailyWorkersByJnoAndDate(ctx context.Context, db Queryer, param entity.RecordDailyWorkerReq) ([]entity.RecordDailyWorkerRes, error)
 	ModifyWorkHours(ctx context.Context, tx Execer, workers entity.WorkerDailys) error
 	GetRecdWorkerList(ctx context.Context, db Queryer) ([]entity.Worker, error)

--- a/csm-api/store/store_compare.go
+++ b/csm-api/store/store_compare.go
@@ -22,9 +22,10 @@ func (r *Repository) GetDailyWorkerList(ctx context.Context, db Queryer, compare
 			ORDER BY
 				CASE COMPARE_STATE
 					WHEN 'S' THEN 1
-					WHEN 'W' THEN 2
-					WHEN 'C' THEN 3
-					ELSE 4
+					WHEN 'X' THEN 2		
+					WHEN 'W' THEN 3
+					WHEN 'C' THEN 4
+					ELSE 5
 				END,
 				CASE 
 					WHEN IN_RECOG_TIME IS NULL THEN OUT_RECOG_TIME 
@@ -43,6 +44,7 @@ func (r *Repository) GetDailyWorkerList(ctx context.Context, db Queryer, compare
 			T1.JNO,
 			T2.USER_ID,
 			T2.USER_NM,
+			T2.PHONE,
 			T2.REG_NO,
 			CASE
 				WHEN INSTR(T2.DEPARTMENT, ' ', -1) > 0 THEN SUBSTR(T2.DEPARTMENT, 1, INSTR(T2.DEPARTMENT, ' ', -1) - 1)


### PR DESCRIPTION
1. 일일근로자관리 tbm, 퇴직공제 업로드 오류 수정: 트랜잭션 처리가 잘못되어 데이터 저장이 안되었음
2. 현장근로자 업로드시 성공한 리스트 반환 및 사유 저장 추가